### PR TITLE
now reads trim values from purdue db

### DIFF
--- a/Gui/GUIutils/DBConnection.py
+++ b/Gui/GUIutils/DBConnection.py
@@ -49,7 +49,8 @@ def QtStartConnection(TryUsername, TryPassword, TryHostAddress, TryDatabase):
             password=str(TryPassword),
             host=str(TryHostAddress),
             database=str(TryDatabase),
-            ssl_disabled=True
+            ssl_disabled=True,
+            connection_timeout = 5000,
         )
     except (ValueError, RuntimeError, TypeError, NameError, mysql.connector.Error):
         msg = QMessageBox()

--- a/Gui/GUIutils/settings.py
+++ b/Gui/GUIutils/settings.py
@@ -53,34 +53,6 @@ DBNames = {
 }
 """
 
-# Note: First element of list will be shown as default value
-# Note: The varibale name is same as hostname
-dblist = []
-
-
-class DBServerIP:
-    All = "All"
-    All_list = ["phase2pixel_test", "DBName2", "DBName3"]
-
-    def __init__(self, DBhostname, DBIP, DBName):
-        self.DBhostname = DBhostname
-        self.DBIP = DBIP
-        self.DBName = DBName
-
-
-Central_remote = DBServerIP(
-    "Central_remote", "0.0.0.0", ["phase2pixel_test", "DBName2", "DBName3"]
-)
-dblist.append(Central_remote.DBhostname)
-local = DBServerIP("local", "127.0.0.1", ["SampleDB", "phase2pixel_test"])
-dblist.append(local.DBhostname)
-OSU_remote = DBServerIP("OSU_remote", "128.146.38.1", ["SampleDB", "phase2pixel_test"])
-dblist.append(OSU_remote.DBhostname)
-Purdue_remote = DBServerIP(
-    "Purdue_remote", "cmsfpixdb.physics.purdue.edu", ["cmsfpix_phase2"]
-)
-dblist.append(Purdue_remote.DBhostname)
-
 # Set the IT_uTDC_firmware for test
 FPGAConfigList = {
     "fc7.board.1": "IT-uDTC_L12-KSU-3xQUAD_L8-KSU2xQUAD_x1G28",

--- a/Gui/QtGUIutils/QtLoginDialog.py
+++ b/Gui/QtGUIutils/QtLoginDialog.py
@@ -39,7 +39,7 @@ import os
 import subprocess
 from subprocess import Popen, PIPE
 
-from Gui.GUIutils.settings import dblist
+# from Gui.GUIutils.settings import dblist
 from Gui.GUIutils.DBConnection import (
     QtStartConnection,
     isActive,
@@ -84,8 +84,8 @@ class QtLoginDialog(QDialog):
 
         if not self.expertMode:
             self.HostName = QComboBox()
-            self.HostName.addItems(dblist)
-            self.HostName.currentIndexChanged.connect(self.changeDBList)
+            # self.HostName.addItems(dblist)
+            # self.HostName.currentIndexChanged.connect(self.changeDBList)
             HostLabel.setBuddy(self.HostName)
         else:
             self.HostEdit = QLineEdit("128.146.38.1")

--- a/Gui/QtGUIutils/QtRunWindow.py
+++ b/Gui/QtGUIutils/QtRunWindow.py
@@ -169,7 +169,7 @@ class QtRunWindow(QWidget):
         )
         HeadLabel.setMaximumHeight(30)
 
-        colorString = "color: green" if self.master.database_connected else "color: red"
+        colorString = "color: green" if self.master.panthera_connected else "color: red"
         StatusLabel = QLabel()
         StatusLabel.setText(self.master.operator_name)
         StatusLabel.setStyleSheet(f"{colorString}; font-size: 14px")
@@ -227,7 +227,7 @@ class QtRunWindow(QWidget):
         # self.SaveButton.clicked.connect(self.saveTest)
         self.saveCheckBox = QCheckBox("&auto-save to Panthera")
         self.saveCheckBox.setMaximumHeight(30)
-        if self.master.database_connected:
+        if self.master.panthera_connected:
             self.saveCheckBox.setChecked(self.testHandler.autoSave)
             self.saveCheckBox.clicked.connect(self.setAutoSave)
         else:
@@ -584,7 +584,7 @@ class QtRunWindow(QWidget):
         if EnableReRun:
             self.RunButton.setText("&Re-run")
             self.RunButton.setDisabled(False)
-            if self.master.database_connected:
+            if self.master.panthera_connected:
                 self.UploadButton.setDisabled(self.testHandler.autoSave)
 
     def updateResult(self, newResult):

--- a/Gui/python/SimplifiedMainWidget.py
+++ b/Gui/python/SimplifiedMainWidget.py
@@ -78,7 +78,7 @@ class SimplifiedMainWidget(QWidget):
         #self.BeBoard.setFPGAConfig(default_settings.FPGAConfigList[site_settings.defaultFC7])
         #logger.debug(f"Default FC7: {site_settings.defaultFC7}")
         logger.debug("Initialized BeBoard in SimplifiedGUI")
-        self.BeBoardWidget = SimpleBeBoardBox(self.firmware)
+        self.BeBoardWidget = SimpleBeBoardBox(self.master, self.firmware)
         logger.debug("Initialized SimpleBeBoardBox in Simplified GUI")
 
     def setupArduino(self):
@@ -440,7 +440,7 @@ class SimplifiedMainWidget(QWidget):
         self.instrument_status["arduino"] = self.ArduinoGroup.ArduinoGoodStatus
         for beboard in self.firmware:
             self.instrument_status[f"fc7_{beboard.getBoardName()}"] = True
-        self.instrument_status["database"] = self.master.database_connected
+        self.instrument_status["database"] = self.master.panthera_connected
 
         # Icicle will deal with the powersupplies, so I will just always set their status to good
         # Technically a false sense of security for the user. 

--- a/Gui/python/TestHandler.py
+++ b/Gui/python/TestHandler.py
@@ -1168,7 +1168,7 @@ class TestHandler(QObject):
                 if not status:
                     raise ConnectionError(message)
         except Exception as e:
-            if not self.master.database_connected:
+            if not self.master.panthera_connected:
                 logger.error("Cannot upload test results, you are not signed in to Panthera.")
             else:
                 logger.error(f"There was an error uploading the test results. {repr(e)}")

--- a/Gui/siteConfig.py
+++ b/Gui/siteConfig.py
@@ -21,20 +21,8 @@ GPIB_DebugMode = False
 
 ##  The following block sets defaults that are to be used in the simplified (non-expert) mode.  ##
 
-# default FC7 boardName
-defaultFC7 = "fc7.board.1"
-# default IP address of IP address
-defaultFC7IP = '192.168.1.80'
-# default FMC board number
-defaultFMC = 'L12'
 # default mode for LV powering (Direct,SLDO,etc)
 defaultPowerMode = "SLDO"
-#default DBServerIP
-#defaultDBServerIP = '127.0.0.1'
-defaultDBServerIP = 'cmsfpixdb.physics.purdue.edu'
-#default DBName
-#defaultDBName = 'SampleDB'
-defaultDBName = 'cmsfpix_phase2'
 
 ##################################
 


### PR DESCRIPTION
Simple:
* Queries DB for trim values based on serial number. If everything works out, it uses those trim values. Otherwise, it uses the default values defined in Firmware.py

Expert:
* Queries DB for module type, module version, and trim values. Automatically sets module type and version based on these results. Then queries DB for trim values and applies those to the relevant ChipBox. If user selects another module type, trim values will reset to default and can be manually edited.