### PR TITLE
Peltier fix

### DIFF
--- a/Gui/QtGUIutils/PeltierCoolingApp.py
+++ b/Gui/QtGUIutils/PeltierCoolingApp.py
@@ -114,6 +114,14 @@ class Peltier(QWidget):
                 )
             )[1]: raise Exception("Could not communicate with Peltier")  # Set proportional bandwidth
 
+
+            # Ensure the Peltier cannot heat up/change polarity to maintain setpoint
+            if not self.pelt.sendCommand(
+                self.pelt.createCommand(
+                    "Heat Multiplier Write", ["0", "0", "0", "0", "0", "0", "0", "0"]
+                )
+            )[1]: raise Exception("Could not communicate with Peltier")
+
             message, _ = self.pelt.sendCommand(
                 self.pelt.createCommand(
                     "Control Output Polarity Read",

--- a/Gui/python/Peltier.py
+++ b/Gui/python/Peltier.py
@@ -37,7 +37,7 @@ class PeltierSignalGenerator:
             "Control Output Polarity Write": ["2", "c"],
             "Control Output Polarity Read": ["4", "5"],
             "Heat Multiplier Write": ["0", "c"],
-            "Heal Multiplier Read": ["5", "c"],
+            "Heat Multiplier Read": ["5", "c"],
             "Cool Multiplier Write": ["0", "d"],
             "Cool Multiplier Read": ["5", "d"]
         }

--- a/Gui/python/Peltier.py
+++ b/Gui/python/Peltier.py
@@ -36,6 +36,10 @@ class PeltierSignalGenerator:
             "Over Current Continuous Read": ["4", "d"],
             "Control Output Polarity Write": ["2", "c"],
             "Control Output Polarity Read": ["4", "5"],
+            "Heat Multiplier Write": ["0", "c"],
+            "Heal Multiplier Read": ["5", "c"],
+            "Cool Multiplier Write": ["0", "d"],
+            "Cool Multiplier Read": ["5", "d"]
         }
         self.checksumError = [
             "*",


### PR DESCRIPTION
Set peltier chip so that heat multiplier is 0. This ensures that the Peltier does not attempt to switch polarities after it has reached the set temperature. 