### PR TITLE
Fix comparison against string literal(s)

### DIFF
--- a/Gui/GUIutils/guiUtils.py
+++ b/Gui/GUIutils/guiUtils.py
@@ -403,8 +403,12 @@ def GenerateXMLConfig(firmwareList, testName, outputDir, **arg):
                 HyBridModule0.SetHyBridName(module.getModuleName())
         
                 moduleType = module.getModuleType()
-                RxPolarities = "1" if "CROC" and "Quad" in moduleType else "0" if "CROC" in moduleType else None        
-                revPolarity = not ("CROC" and "1x2" in moduleType)
+                
+                RxPolarities = None
+                RxPolarities = "0" if "CROC" in moduleType
+                RxPolarities = "1" if "CROC" in moduleType and "Quad" in moduleType
+                
+                revPolarity = not ("CROC" in moduleType and "1x2" in moduleType)
                 FESettings_Dict = FESettings_DictB if "CROC" in moduleType else FESettings_DictA
                 globalSettings_Dict = globalSettings_DictB if "CROC" in moduleType else globalSettings_DictA
                 HWSettings_Dict = HWSettings_DictB if "CROC" in moduleType else HWSettings_DictA

--- a/Gui/GUIutils/guiUtils.py
+++ b/Gui/GUIutils/guiUtils.py
@@ -405,9 +405,9 @@ def GenerateXMLConfig(firmwareList, testName, outputDir, **arg):
                 moduleType = module.getModuleType()
                 
                 RxPolarities = None
-		        if "CROC" in moduleType:
+                if "CROC" in moduleType:
                     RxPolarities = "0"
-		        if "CROC" in moduleType and "Quad" in moduleType:
+                if "CROC" in moduleType and "Quad" in moduleType:
                     RxPolarities = "1" 
                 
                 revPolarity = not ("CROC" in moduleType and "1x2" in moduleType)

--- a/Gui/GUIutils/guiUtils.py
+++ b/Gui/GUIutils/guiUtils.py
@@ -405,8 +405,10 @@ def GenerateXMLConfig(firmwareList, testName, outputDir, **arg):
                 moduleType = module.getModuleType()
                 
                 RxPolarities = None
-                RxPolarities = "0" if "CROC" in moduleType
-                RxPolarities = "1" if "CROC" in moduleType and "Quad" in moduleType
+		        if "CROC" in moduleType:
+                    RxPolarities = "0"
+		        if "CROC" in moduleType and "Quad" in moduleType:
+                    RxPolarities = "1" 
                 
                 revPolarity = not ("CROC" in moduleType and "1x2" in moduleType)
                 FESettings_Dict = FESettings_DictB if "CROC" in moduleType else FESettings_DictA


### PR DESCRIPTION
Cheers,

The XMLs generated for my TEPX CROCv1 Quad seem to contain incorrect polarity settings. I tracked the issue down to a couple of comparisons like `"CROC" and "1x2" in moduleType` which always evaluate to True.

I would verify the first line changed, since I'm not 100% sure about the intended logic.

Thanks