### PR TITLE
Add retry button for failed Tests

### DIFF
--- a/Gui/QtGUIutils/QtRunWindow.py
+++ b/Gui/QtGUIutils/QtRunWindow.py
@@ -107,6 +107,7 @@ class QtRunWindow(QWidget):
         # Fixme: QTimer to be added to update the page automatically
         self.grades = []
         self.modulestatus = []
+        self.finished_tests = []
         self.autoSave = False
 
         self.mainLayout = QGridLayout()
@@ -458,12 +459,12 @@ class QtRunWindow(QWidget):
         print("attempting to update status in history")
         self.HistoryLayout.removeWidget(self.StatusTable)
         self.StatusTable.setRowCount(0)
-        for index, test_results in enumerate(self.modulestatus):
+        for test, test_results in zip(self.finished_tests, self.modulestatus):
             row = self.StatusTable.rowCount()
             self.StatusTable.setRowCount(row + 1)
             if isCompositeTest(self.info):
                 self.StatusTable.setItem(
-                    row, 0, QTableWidgetItem(CompositeTests[self.info][index % len(CompositeTests[self.info])])
+                    row, 0, QTableWidgetItem(test)
                 )
             else:
                 self.StatusTable.setItem(row, 0, QTableWidgetItem(self.info))
@@ -617,6 +618,12 @@ class QtRunWindow(QWidget):
     def updateValidation(self, results:list):
         try:
             self.modulestatus.append(results)
+        except Exception as err:
+            logger.error(err)
+
+    def updateFinishedTests(self, tests:list):
+        try:
+            self.finished_tests = tests
         except Exception as err:
             logger.error(err)
 

--- a/Gui/python/TestHandler.py
+++ b/Gui/python/TestHandler.py
@@ -71,6 +71,7 @@ class TestHandler(QObject):
     updateIVResult = pyqtSignal(object)
     updateSLDOResult = pyqtSignal(object)
     updateValidation = pyqtSignal(object)
+    updateFinishedTests = pyqtSignal(object)
     powerSignal = pyqtSignal()
 
     def __init__(self, runwindow, master, info, firmware):
@@ -114,7 +115,7 @@ class TestHandler(QObject):
         self.SLDOScanHandler = None
 
         self.processingFlag = False
-        self.ProgressBarList = []
+        self.ProgresBarList = []
         self.input_dir = ""
         self.output_dir = ""
         self.config_file = (
@@ -179,7 +180,9 @@ class TestHandler(QObject):
         self.updateIVResult.connect(self.runwindow.updateIVResult)
         self.updateSLDOResult.connect(self.runwindow.updateSLDOResult)
         self.updateValidation.connect(self.runwindow.updateValidation)
+        self.updateFinishedTests.connect(self.runwindow.updateFinishedTests)
 
+        self.finished_tests = []
 
         self.initializeRD53Dict()
 
@@ -307,7 +310,6 @@ class TestHandler(QObject):
         self.config_file = ""
         return
 
-
     def saveConfigs(self):
         for key in self.rd53_file.keys():
             try:
@@ -350,7 +352,7 @@ class TestHandler(QObject):
         else:
             QMessageBox.information(None, "Warning", "Not a valid test", QMessageBox.Ok)
             return
-
+        
     # This loops over all the tests by using the on_finish pyqt decorator defined below
     def runCompositeTest(self, testName):
         if self.halt:
@@ -603,6 +605,7 @@ class TestHandler(QObject):
         self.starttime = None
 
     def validateTest(self):
+        self.finished_tests.append(self.currentTest)
         try:
             passed = []
             results = []
@@ -628,8 +631,9 @@ class TestHandler(QObject):
                         passed.append(list(result.values())[0][0])
                                                 
                         self.figurelist[module.getModuleName()] = self.collect_plots(module.getModuleName())
-                        
+            
             self.updateValidation.emit(results)
+            self.updateFinishedTests.emit(self.finished_tests)
             return all(passed)
         except Exception as err:
             logger.error(err)
@@ -951,6 +955,7 @@ class TestHandler(QObject):
             self.updateResult.emit((step, self.figurelist))
 
         # self.update()
+            
 
         if (
             status == False
@@ -1092,10 +1097,10 @@ class TestHandler(QObject):
             self.figurelist[moduleName] = [filename]
 
         status = self.validateTest()
+
         step="IVCurve"
 
         self.testIndexTracker += 1
-
 
         EnableReRun = False
 
@@ -1129,12 +1134,20 @@ class TestHandler(QObject):
         else: 
             self.updateIVResult.emit((step, self.figurelist))  ##Add else statement to add signal in simple mode
 
+        if (
+            status == False
+            and isCompositeTest(self.info)
+            and self.testIndexTracker < len(CompositeTests[self.info])
+        ):
+            self.forceContinue()
+
         if isCompositeTest(self.info):
             self.runTest()
 
     def SLDOScanFinished(self):
         status = self.validateTest()
         self.testIndexTracker += 1
+
         EnableReRun = False
         # Will send signal to turn off power supply after composite or single tests are run
         if isCompositeTest(self.info):
@@ -1169,7 +1182,14 @@ class TestHandler(QObject):
             self.updateSLDOResult.emit(self.output_dir)
         else: 
             self.updateSLDOResult.emit(("SLDOScan", self.figurelist))  ##Add else statement to add signal in simple mode
-        
+
+        if (
+            status == False
+            and isCompositeTest(self.info)
+            and self.testIndexTracker < len(CompositeTests[self.info])
+        ):
+            self.forceContinue()
+
         if isCompositeTest(self.info):
             self.runTest()
 
@@ -1177,21 +1197,33 @@ class TestHandler(QObject):
         pass
 
     def forceContinue(self):
-        reply = QMessageBox.question(
-            None,
-            "Abort following tests",
-            "Failed component detected, continue to following test?",
-            QMessageBox.No | QMessageBox.Yes,
-            QMessageBox.No,
-        )
+        msg_box = QMessageBox()
+        msg_box.setWindowTitle("Failed Component Detected")
+        msg_box.setText("Failed component detected. What would you like to do?")
 
-        if reply == QMessageBox.Yes:
-            return
-        else:
+        # Add custom buttons
+        exit_button = msg_box.addButton("Exit", QMessageBox.RejectRole)
+        retry_button = msg_box.addButton("Retry", QMessageBox.ActionRole)
+        continue_button = msg_box.addButton("Continue", QMessageBox.AcceptRole)
+        msg_box.setDefaultButton(exit_button)
+
+        # Show the message box and wait for the user's choice
+        msg_box.exec()
+
+        # Check which button was clicked
+        if msg_box.clickedButton() == exit_button:
             self.run_process.kill()
             self.halt = True
             self.haltSignal.emit(self.halt)
             self.starttime = None
+        elif msg_box.clickedButton() == retry_button:
+            self.outputString.emit(f'Retrying {self.currentTest}...')
+            self.testIndexTracker = CompositeTests[self.info].index(self.currentTest)
+            self.runwindow.ResultWidget.runtime[self.testIndexTracker].setText("")
+            self.runwindow.ResultWidget.ProgressBar[self.testIndexTracker].setValue(0)
+            QApplication.processEvents() #not ideal. May need to fix later.
+        elif msg_box.clickedButton() == continue_button:
+            return
 
     def upload_to_Panthera(self):
         try:


### PR DESCRIPTION
I also added the forceContinue() prompt for failed IVCurves and SLDOScans which wasn't the case before.

When retrying IVCurve (and maybe other tests) the terminal outputs

` cannot stat [sic?] '~directory~' No such file or directory `

It's because when you run a new test, TestHandler.configTest() is called which sets an OUTPUT_DIR with a new timestamp.

I don't think this negatively impacts the retry test, but I'm not sure what the proper way to navigate this is. It seems like the retry test runs smoothly after this line, but maybe I'm missing something.