### PR TITLE
Fixed root file functionality

### DIFF
--- a/Gui/QtGUIutils/QtRunWindow.py
+++ b/Gui/QtGUIutils/QtRunWindow.py
@@ -443,7 +443,8 @@ class QtRunWindow(QWidget):
         self.master.ProcessingTest = True
 
     def release(self):
-        self.abortTest()
+        self.j = 0 #deprecated?
+        self.testhandler.abortTest()
         self.master.ProcessingTest = False
         if self.master.expertMode == True:
             self.master.NewTestButton.setDisabled(False)
@@ -541,8 +542,19 @@ class QtRunWindow(QWidget):
         self.testHandler.runTest(isReRun)
 
     def abortTest(self):
-        self.j = 0
-        self.testHandler.abortTest()
+        reply = QMessageBox.question(
+            None,
+            "Abort",
+            "Are you sure to abort?",
+            QMessageBox.No | QMessageBox.Yes,
+            QMessageBox.No,
+        )
+
+        if reply == QMessageBox.Yes:
+            self.j = 0 #deprecated?
+            self.testHandler.abortTest()
+        else:
+            return
 
     def urgentStop(self):
         self.testHandler.urgentStop()

--- a/Gui/python/TestHandler.py
+++ b/Gui/python/TestHandler.py
@@ -4,6 +4,7 @@ from PyQt5.QtWidgets import QMessageBox
 
 import sys
 import os
+import glob
 import re
 import subprocess
 import threading
@@ -440,7 +441,6 @@ class TestHandler(QObject):
         self.updateOptimizedXMLValues()
         self.configTest()
 
-        
         self.outputFile = self.output_dir + "/output.txt"
         self.errorFile = self.output_dir + "/error.txt"
 
@@ -572,29 +572,18 @@ class TestHandler(QObject):
         # self.finishSingal = False
 
     def abortTest(self):
-        reply = QMessageBox.question(
-            None,
-            "Abort",
-            "Are you sure to abort?",
-            QMessageBox.No | QMessageBox.Yes,
-            QMessageBox.No,
-        )
+        self.halt = True
+        self.run_process.kill()
 
-        if reply == QMessageBox.Yes:
-            self.halt = True
-            self.run_process.kill()
+        self.haltSignal.emit(self.halt)
 
-            self.haltSignal.emit(self.halt)
-
-            self.starttime = None
-            if self.IVCurveHandler:
-                self.outputString.emit("Aborting IVCurve")
-                self.IVCurveHandler.stop()
-            if self.SLDOScanHandler:
-                self.outputString.emit("Aborting SLDOScan")
-                self.SLDOScanHandler.stop()
-        else:
-            return
+        self.starttime = None
+        if self.IVCurveHandler:
+            self.outputString.emit("Aborting IVCurve")
+            self.IVCurveHandler.stop()
+        if self.SLDOScanHandler:
+            self.outputString.emit("Aborting SLDOScan")
+            self.SLDOScanHandler.stop()
 
     def urgentStop(self):
         self.run_process.kill()
@@ -655,6 +644,23 @@ class TestHandler(QObject):
             else:
                 print('testHandler.collect_plots Exception:', repr(e))
                 return []
+    
+    #For root files with the same RunNumber in the PH2ACF directory, this function only copies over to
+    #self.output_dir the .root file modified most recently. This will copy over the wrong file if somebody
+    #manually edits the .root file in the PH2ACF directory, so there may be a better way to do this
+    def copyMostRecentRootFile(self,RunNumber,base_dir,output_dir):
+        # Construct the search pattern for files
+        search_pattern = f"{base_dir}/Run{RunNumber}*.root"
+
+        # Find all matching files
+        matching_files = glob.glob(search_pattern)
+        print(matching_files)
+
+        # Sort files by modification time (newest first)
+        latest_file = max(matching_files, key=os.path.getmtime)
+        
+        # Copy the most recent file to the output directory
+        os.system(f"cp {latest_file} {output_dir}/")
 
     def saveTest(self):
         # if self.parent.current_test_grade < 0:
@@ -664,21 +670,12 @@ class TestHandler(QObject):
 
         try:
             if self.RunNumber == "-1":
-                os.system(
-                    "cp {0}/test/Results/Run000000*.root {1}/".format(
-                        os.environ.get("PH2ACF_BASE_DIR"), self.output_dir
-                    )
-                )
+
+                self.copyMostRecentRootFile(000000,os.environ.get("PH2ACF_BASE_DIR")+"/test/Results",self.output_dir)
                 # os.system("cp {0}/test/Results/Run000000*.txt {1}/".format(os.environ.get("PH2ACF_BASE_DIR"),self.output_dir))
                 # os.system("cp {0}/test/Results/Run000000*.xml {1}/".format(os.environ.get("PH2ACF_BASE_DIR"),self.output_dir))
             else:
-                os.system(
-                    "cp {0}/test/Results/Run{1}*.root {2}/".format(
-                        os.environ.get("PH2ACF_BASE_DIR"),
-                        self.RunNumber,
-                        self.output_dir,
-                    )
-                )
+                self.copyMostRecentRootFile(self.RunNumber,os.environ.get("PH2ACF_BASE_DIR")+"/test/Results",self.output_dir)
                 # os.system("cp {0}/test/Results/Run{1}*.txt {2}/".format(os.environ.get("PH2ACF_BASE_DIR"),self.RunNumber,self.output_dir))
                 # os.system("cp {0}/test/Results/Run{1}*.xml {2}/".format(os.environ.get("PH2ACF_BASE_DIR"),self.RunNumber,self.output_dir))
         except:
@@ -900,6 +897,7 @@ class TestHandler(QObject):
     def on_finish(self):
         self.outputfile.close()
         # While the process is killed:
+
         if self.halt == True:
             self.haltSignal.emit(True)
             return

--- a/Gui/python/TestHandler.py
+++ b/Gui/python/TestHandler.py
@@ -36,6 +36,7 @@ from Gui.GUIutils.guiUtils import (
 from Gui.python.ROOTInterface import executeCommandSequence
 from felis.felis import Felis
 from InnerTrackerTests.Analysis.IVCurve_CSV_to_ROOT import IVCurve_CSV_to_ROOT
+from InnerTrackerTests.RootFilesDict import root_files
 
 # from Gui.QtGUIutils.QtStartWindow import *
 #from Gui.QtGUIutils.QtCustomizeWindow import *
@@ -648,19 +649,21 @@ class TestHandler(QObject):
     #For root files with the same RunNumber in the PH2ACF directory, this function only copies over to
     #self.output_dir the .root file modified most recently. This will copy over the wrong file if somebody
     #manually edits the .root file in the PH2ACF directory, so there may be a better way to do this
-    def copyMostRecentRootFile(self,RunNumber,base_dir,output_dir):
-        # Construct the search pattern for files
-        search_pattern = f"{base_dir}/Run{RunNumber}*.root"
-
-        # Find all matching files
-        matching_files = glob.glob(search_pattern)
-        print(matching_files)
-
-        # Sort files by modification time (newest first)
-        latest_file = max(matching_files, key=os.path.getmtime)
+    def copyMostRecentRootFile(self,RunNumber,base_dir,output_dir,test):
         
-        # Copy the most recent file to the output directory
-        os.system(f"cp {latest_file} {output_dir}/")
+        files = root_files[test] if test in root_files.keys() else (test)
+        for name in files:
+            # Construct the search pattern for files
+            search_pattern = f"{base_dir}/Run{RunNumber}_{name}.root"
+
+            # Find all matching files
+            matching_files = glob.glob(search_pattern)
+
+            # Sort files by modification time (newest first)
+            latest_file = max(matching_files, key=os.path.getmtime)
+
+            # Copy the most recent file to the output directory
+            os.system(f"cp {latest_file} {output_dir}/")
 
     def saveTest(self):
         # if self.parent.current_test_grade < 0:
@@ -671,11 +674,12 @@ class TestHandler(QObject):
         try:
             if self.RunNumber == "-1":
 
-                self.copyMostRecentRootFile(000000,os.environ.get("PH2ACF_BASE_DIR")+"/test/Results",self.output_dir)
+                self.copyMostRecentRootFile(000000,os.environ.get("PH2ACF_BASE_DIR")+"/test/Results",self.output_dir,self.currentTest)
+
                 # os.system("cp {0}/test/Results/Run000000*.txt {1}/".format(os.environ.get("PH2ACF_BASE_DIR"),self.output_dir))
                 # os.system("cp {0}/test/Results/Run000000*.xml {1}/".format(os.environ.get("PH2ACF_BASE_DIR"),self.output_dir))
             else:
-                self.copyMostRecentRootFile(self.RunNumber,os.environ.get("PH2ACF_BASE_DIR")+"/test/Results",self.output_dir)
+                self.copyMostRecentRootFile(self.RunNumber,os.environ.get("PH2ACF_BASE_DIR")+"/test/Results",self.output_dir,self.currentTest)
                 # os.system("cp {0}/test/Results/Run{1}*.txt {2}/".format(os.environ.get("PH2ACF_BASE_DIR"),self.RunNumber,self.output_dir))
                 # os.system("cp {0}/test/Results/Run{1}*.xml {2}/".format(os.environ.get("PH2ACF_BASE_DIR"),self.RunNumber,self.output_dir))
         except:
@@ -913,7 +917,7 @@ class TestHandler(QObject):
         EnableReRun = False
 
         # Save the output ROOT file to output_dir
-        self.saveTest()
+        self.saveTest(self.currentTest)
 
         # validate the results
         status = self.validateTest()


### PR DESCRIPTION
Fixed root file copying for tests with multiple root files. Made a dictionary for tests that have multiple root files in RootFilesDict.py.
This commit only added InjectionDelay to that dictionary.