### PR TITLE
Parallel-minidaqs

### DIFF
--- a/Gui/GUIutils/guiUtils.py
+++ b/Gui/GUIutils/guiUtils.py
@@ -380,8 +380,9 @@ def CheckXMLValue(pFilename, pAttribute):
 ##########################################################################
 
 
-def GenerateXMLConfig(firmwareList, testName, outputDir, **arg):
+def GenerateXMLConfig(firmwareList, testName, outputDir, statuses, **arg):
     outputFile = outputDir + "/CMSIT_" + testName + ".xml"
+    print(outputFile)
     
     boardtype = "RD53A"
     RegisterSettingsList = RegisterSettings #TODO: Investigate whether this actually matters (ie deep vs shallow copy)
@@ -400,7 +401,7 @@ def GenerateXMLConfig(firmwareList, testName, outputDir, **arg):
             # Set up each module within the optical group
             for module in og.getAllModules().values():
                 HyBridModule0 = HyBridModule()
-                HyBridModule0.SetHyBridModule(module.getFMCPort(), "1")
+                HyBridModule0.SetHyBridModule(module.getFMCPort(), statuses[module.getModuleName()])
                 HyBridModule0.SetHyBridName(module.getModuleName())
         
                 moduleType = module.getModuleType()

--- a/Gui/GUIutils/guiUtils.py
+++ b/Gui/GUIutils/guiUtils.py
@@ -87,7 +87,6 @@ def iter_except(function, exception):
 ##########################################################################
 ##########################################################################
 
-
 def ConfigureTest(Test, Module_ID, Output_Dir, Input_Dir):
     if not Output_Dir:
         test_dir = os.environ.get("DATA_dir") + "/Test_" + str(Test)
@@ -152,21 +151,21 @@ def isActive(dbconnection):
 ##########################################################################
 
 
-def SetupXMLConfig(Input_Dir, Output_Dir):
+def SetupXMLConfig(Input_Dir, Output_Dir, BeBoardName=""):
     try:
-        os.system("cp {0}/CMSIT.xml {1}/CMSIT.xml".format(Input_Dir, Output_Dir))
+        os.system("cp {0}/CMSIT_{2}.xml {1}/CMSIT_2.xml".format(Input_Dir, Output_Dir, BeBoardName))
     except OSError:
         print("Can not copy the XML files to {0}".format(Output_Dir))
     try:
         os.system(
-            "cp {0}/CMSIT.xml  {1}/test/CMSIT.xml".format(
-                Output_Dir, os.environ.get("PH2ACF_BASE_DIR")
+            "cp {0}/CMSIT_{2}.xml  {1}/test/CMSIT_{2}.xml".format(
+                Output_Dir, os.environ.get("PH2ACF_BASE_DIR"), BeBoardName
             )
         )
     except OSError:
         print(
-            "Can not copy {0}/CMSIT.xml to {1}/test/CMSIT.xml".format(
-                Output_Dir, os.environ.get("PH2ACF_BASE_DIR")
+            "Can not copy {0}/CMSIT_{2}.xml to {1}/test/CMSIT_{2}.xml".format(
+                Output_Dir, os.environ.get("PH2ACF_BASE_DIR"), BeBoardName
             )
         )
 
@@ -175,7 +174,7 @@ def SetupXMLConfig(Input_Dir, Output_Dir):
 ##########################################################################
 
 
-def SetupXMLConfigfromFile(InputFile, Output_Dir, firmware, RD53Dict):
+def SetupXMLConfigfromFile(InputFile, Output_Dir, BeBoardName=""):
     changeMade = False
     try:
         root, tree = LoadXML(InputFile)
@@ -275,19 +274,19 @@ def SetupXMLConfigfromFile(InputFile, Output_Dir, firmware, RD53Dict):
         print("Failed to set up the XML file, {}".format(error))
 
     try:
-        os.system("cp {0} {1}/CMSIT.xml".format(InputFile, Output_Dir))
+        os.system("cp {0} {1}/CMSIT_{2}.xml".format(InputFile, Output_Dir, BeBoardName))
     except OSError:
         print("Can not copy the XML files {0} to {1}".format(InputFile, Output_Dir))
     try:
         os.system(
-            "cp {0}/CMSIT.xml  {1}/test/CMSIT.xml".format(
-                Output_Dir, os.environ.get("PH2ACF_BASE_DIR")
+            "cp {0}/CMSIT_{1}.xml  {2}/test/CMSIT_{1}.xml".format(
+                Output_Dir, BeBoardName, os.environ.get("PH2ACF_BASE_DIR")
             )
         )
     except OSError:
         print(
-            "Can not copy {0}/CMSIT.xml to {1}/test/CMSIT.xml".format(
-                Output_Dir, os.environ.get("PH2ACF_BASE_DIR")
+            "Can not copy {0}/CMSIT_{1}.xml to {2}/test/CMSIT_{1}.xml".format(
+                Output_Dir, BeBoardName, os.environ.get("PH2ACF_BASE_DIR")
             )
         )
 
@@ -379,9 +378,8 @@ def CheckXMLValue(pFilename, pAttribute):
 ##########################################################################
 ##########################################################################
 
-
-def GenerateXMLConfig(firmwareList, testName, outputDir, statuses, **arg):
-    outputFile = outputDir + "/CMSIT_" + testName + ".xml"
+def GenerateXMLConfig(BeBoard, testName, outputDir, **arg):
+    outputFile = f'{outputDir}/CMSIT_{BeBoard.getBoardName()}_{testName}.xml'
     print(outputFile)
     
     boardtype = "RD53A"
@@ -390,53 +388,53 @@ def GenerateXMLConfig(firmwareList, testName, outputDir, statuses, **arg):
     
     # Get Hardware discription and a list of the modules
     HWDescription0 = HWDescription()
-    for BeBoard in firmwareList:
-        BeBoardModule0 = BeBoardModule()
+    
+    BeBoardModule0 = BeBoardModule()
 
-        #Set up Optical Groups
-        for og in BeBoard.getAllOpticalGroups().values():
-            OpticalGroupModule0 = OGModule()
-            OpticalGroupModule0.SetOpticalGrp(og.getOpticalGroupID(), og.getFMCID())
-            
-            # Set up each module within the optical group
-            for module in og.getAllModules().values():
-                HyBridModule0 = HyBridModule()
-                HyBridModule0.SetHyBridModule(module.getFMCPort(), statuses[module.getModuleName()])
-                HyBridModule0.SetHyBridName(module.getModuleName())
+    #Set up Optical Groups
+    for og in BeBoard.getAllOpticalGroups().values():
+        OpticalGroupModule0 = OGModule()
+        OpticalGroupModule0.SetOpticalGrp(og.getOpticalGroupID(), og.getFMCID())
         
-                moduleType = module.getModuleType()
-                RxPolarities = "1" if "CROC" in moduleType and "Quad" in moduleType and "TFPX" in moduleType else "0" if "CROC" in moduleType else None
-                revPolarity = bool(int(RxPolarities))
-                FESettings_Dict = FESettings_DictB if "CROC" in moduleType else FESettings_DictA
-                globalSettings_Dict = globalSettings_DictB if "CROC" in moduleType else globalSettings_DictA
-                HWSettings_Dict = HWSettings_DictB if "CROC" in moduleType else HWSettings_DictA
-                FELaneConfig_Dict = FELaneConfig_DictB[module.getModuleType().split(" ")[0]] if "CROC" in moduleType else None
-                boardtype = "RD53B"+module.getModuleVersion() if "CROC" in moduleType else "RD53A"
-                
-                # Sets up all the chips on the module and adds them to the hybrid module to then be stored in the class
-                for chip in module.getChips().values():
-                    print("chip {0} status is {1}".format(chip.getID(), chip.getStatus()))
-                    FEChip = FE()
-                    FEChip.SetFE(
-                        chip.getID(),
-                        "1" if chip.getStatus() else "0",
-                        chip.getLane(),
-                        RxPolarities,
-                        "CMSIT_RD53_{0}_{1}_{2}.txt".format(
-                            module.getModuleName(), module.getFMCPort(), chip.getID()
-                        ),
-                    )
-                    
-                    FEChip.ConfigureFE(FESettings_Dict[testName])
-                    FEChip.ConfigureLaneConfig(FELaneConfig_Dict[testName][int(chip.getLane())])
-                    FEChip.VDDAtrim = chip.getVDDA()
-                    FEChip.VDDDtrim = chip.getVDDD()
-                    FEChip.EfuseID = chip.getEfuseID()
-                    HyBridModule0.AddFE(FEChip)
-                HyBridModule0.ConfigureGlobal(globalSettings_Dict[testName])
-                OpticalGroupModule0.AddHyBrid(HyBridModule0)
+        # Set up each module within the optical group
+        for module in og.getAllModules().values():
+            HyBridModule0 = HyBridModule()
+            HyBridModule0.SetHyBridModule(module.getFMCPort(), module.getEnabled())
+            HyBridModule0.SetHyBridName(module.getModuleName())
+    
+            moduleType = module.getModuleType()
+            RxPolarities = "1" if "CROC" in moduleType and "Quad" in moduleType and "TFPX" in moduleType else "0" if "CROC" in moduleType else None
+            revPolarity = bool(int(RxPolarities))
+            FESettings_Dict = FESettings_DictB if "CROC" in moduleType else FESettings_DictA
+            globalSettings_Dict = globalSettings_DictB if "CROC" in moduleType else globalSettings_DictA
+            HWSettings_Dict = HWSettings_DictB if "CROC" in moduleType else HWSettings_DictA
+            FELaneConfig_Dict = FELaneConfig_DictB[module.getModuleType().split(" ")[0]] if "CROC" in moduleType else None
+            boardtype = "RD53B"+module.getModuleVersion() if "CROC" in moduleType else "RD53A"
             
-            BeBoardModule0.AddOGModule(OpticalGroupModule0)
+            # Sets up all the chips on the module and adds them to the hybrid module to then be stored in the class
+            for chip in module.getChips().values():
+                print("chip {0} status is {1}".format(chip.getID(), chip.getStatus()))
+                FEChip = FE()
+                FEChip.SetFE(
+                    chip.getID(),
+                    "1" if chip.getStatus() else "0",
+                    chip.getLane(),
+                    RxPolarities,
+                    "CMSIT_RD53_{0}_{1}_{2}.txt".format(
+                        module.getModuleName(), module.getFMCPort(), chip.getID()
+                    ),
+                )
+                
+                FEChip.ConfigureFE(FESettings_Dict[testName])
+                FEChip.ConfigureLaneConfig(FELaneConfig_Dict[testName][int(chip.getLane())])
+                FEChip.VDDAtrim = chip.getVDDA()
+                FEChip.VDDDtrim = chip.getVDDD()
+                FEChip.EfuseID = chip.getEfuseID()
+                HyBridModule0.AddFE(FEChip)
+            HyBridModule0.ConfigureGlobal(globalSettings_Dict[testName])
+            OpticalGroupModule0.AddHyBrid(HyBridModule0)
+        
+        BeBoardModule0.AddOGModule(OpticalGroupModule0)
         
         if revPolarity == True:
             RegisterSettingsList['user.ctrl_regs.gtx_rx_polarity.fmc_l12'] = '0b1101'

--- a/Gui/QtGUIutils/Loading.py
+++ b/Gui/QtGUIutils/Loading.py
@@ -2,13 +2,13 @@ from PyQt5.QtWidgets import QWidget
 from PyQt5.QtCore import Qt, QTimer, QThread, pyqtSignal
 from PyQt5.QtGui import QPainter, QPen
 
-#class
 class LoadingThread(QThread):
     finished_signal = pyqtSignal()
     def __init__(self,function,interval,*args):
         super(LoadingThread, self).__init__()
         self.function = function
         self.args = args
+        self.finished_signal.connect(lambda : self.timer.stop())
         self.timer = QTimer()
         self.timer.setInterval(interval)
 
@@ -23,7 +23,7 @@ class LoadingWheel(QWidget):
         self.angle = 0
 
     def update_spinner(self):
-        self.angle = (self.angle + 10) % 360  # Rotate by 10 degrees
+        self.angle = (self.angle + 10) % 360  # Rotate by 10 degrees'
         self.update()  # Trigger repaint
 
     def paintEvent(self, event):
@@ -32,7 +32,7 @@ class LoadingWheel(QWidget):
         painter.translate(self.width() / 2, self.height() / 2)  # Center rotation
         painter.rotate(self.angle)
 
-        pen = QPen(Qt.blue, 2, Qt.SolidLine, Qt.RoundCap)
+        pen = QPen(Qt.white, 2, Qt.SolidLine, Qt.RoundCap)
         painter.setPen(pen)
 
         # Draw arc as spinner

--- a/Gui/QtGUIutils/QtApplication.py
+++ b/Gui/QtGUIutils/QtApplication.py
@@ -60,7 +60,7 @@ from Gui.python.logging_config import logger
 
 class QtApplication(QWidget):
     globalStop = pyqtSignal()
-
+    errorMessageBoxSignal = pyqtSignal(str)
     def __init__(self, dimension):
         super(QtApplication, self).__init__()
         self.mainLayout = QGridLayout()
@@ -100,6 +100,15 @@ class QtApplication(QWidget):
         self.setLoginUI()
         self.initLog()
         self.createLogin()
+
+        self.errorMessageBoxSignal.connect( lambda message :
+            QMessageBox.information(
+                None,
+                "Error",
+                message,
+                QMessageBox.Ok,
+            )
+        )
 
     def setLoginUI(self):
         self.setGeometry(300, 300, 400, 500)
@@ -998,9 +1007,7 @@ class QtApplication(QWidget):
 
             except Exception as e:
                 print("Error:", e)
-                QMessageBox.information(
-                    None, "Error", "Please Check Instrument Connections", QMessageBox.Ok
-                )
+                self.errorMessageBoxSignal.emit("Please Check Instrument Connections")
                 self.instruments = None
 
         if self.expertMode:                

--- a/Gui/QtGUIutils/QtApplication.py
+++ b/Gui/QtGUIutils/QtApplication.py
@@ -807,8 +807,8 @@ class QtApplication(QWidget):
             title_label.setStyleSheet("color: gold;")  # Gold text
             title_label.setAlignment(Qt.AlignCenter)
 
-            # Warning subtitle (Proceed at risk)
-            subtitle_label = QLabel("⚠ Proceed at risk ⚠")
+            # Warning subtitle (Proceed with caution)
+            subtitle_label = QLabel("⚠ Proceed with Caution ⚠")
             subtitle_label.setFont(QFont("Arial", 12, QFont.Bold))
             subtitle_label.setStyleSheet("color: red;")  # Red warning text
             subtitle_label.setAlignment(Qt.AlignCenter)
@@ -953,14 +953,10 @@ class QtApplication(QWidget):
     def connect_devices_starter(self):
         self.Wheel.setVisible(True)
         self.connect_devices_thread = LoadingThread(self.connect_devices,50)
-        self.connect_devices_thread.finished.connect(self.connect_devices_onFinish)
+        self.connect_devices_thread.finished.connect(lambda : self.Wheel.close())
         self.connect_devices_thread.timer.timeout.connect(self.Wheel.update_spinner)
         self.connect_devices_thread.timer.start()
         self.connect_devices_thread.start()  # Start the thread
-
-    def connect_devices_onFinish(self):
-        self.connect_devices_thread.timer.stop()
-        self.Wheel.setVisible(False)
 
     def connect_devices(self):
         

--- a/Gui/QtGUIutils/QtRunWindow.py
+++ b/Gui/QtGUIutils/QtRunWindow.py
@@ -681,6 +681,7 @@ class QtRunWindow(QWidget):
                                             "instruments manually",
                                             QMessageBox.Ok)
                 event.accept()
+                if hasattr(self.testHandler, "fail_window"): self.testHandler.fail_window.close()
             else:
                 self.backSignal = False
                 event.ignore()

--- a/Gui/QtGUIutils/QtRunWindow.py
+++ b/Gui/QtGUIutils/QtRunWindow.py
@@ -134,7 +134,7 @@ class QtRunWindow(QWidget):
 
     
     def onPowerSignal(self):
-        starting_voltages = [int(np.abs(int(getattr(module["hv"], "voltage")))) for module in self.master.instruments._module_dict.values()]
+        starting_voltages = [np.abs(getattr(module["hv"], "voltage")) for module in self.master.instruments._module_dict.values()]
         self.master.instruments.off(
                 hv_delay=0.3, hv_step_size=10, measure=False,
                 execute_each_step=lambda:self.testHandler.ramp_progress_bar(starting_voltages)
@@ -452,9 +452,9 @@ class QtRunWindow(QWidget):
 
     def release(self):
         self.testHandler.halt = False
-        print('err1')
+
         self.testHandler.run_process.kill()
-        print('err2')
+
 
         self.testHandler.starttime = None
         if self.testHandler.IVCurveHandler:
@@ -707,7 +707,6 @@ class QtRunWindow(QWidget):
                 self.release()
                 if self.master.instruments:
                     starting_voltages = [np.abs(getattr(module["hv"], "voltage")) for module in self.master.instruments._module_dict.values()]
-                    print(1)
                     self.master.instruments.off(
                         hv_delay=0.3, hv_step_size=10, execute_each_step=lambda:self.testHandler.ramp_progress_bar(starting_voltages)
                     )

--- a/Gui/QtGUIutils/QtRunWindow.py
+++ b/Gui/QtGUIutils/QtRunWindow.py
@@ -22,22 +22,14 @@ import os, numpy as np
 import threading
 import Gui.siteSettings as site_settings
 
-from Gui.GUIutils.DBConnection import checkDBConnection
-from Gui.GUIutils.guiUtils import isActive, isCompositeTest
+from Gui.GUIutils.guiUtils import isCompositeTest
 
-# from Gui.QtGUIutils.QtStartWindow import *
 from Gui.QtGUIutils.QtCustomizeWindow import QtCustomizeWindow
-#from Gui.QtGUIutils.QtTableWidget import *
-#from Gui.QtGUIutils.QtMatplotlibUtils import *
-from Gui.QtGUIutils.QtLoginDialog import QtLoginDialog
+from Gui.QtGUIutils.Loading import LoadingThread, LoadingWheel
 from Gui.python.ResultTreeWidget import ResultTreeWidget
-#from Gui.python.TestValidator import *
-#from Gui.python.ANSIColoringParser import *
 from Gui.python.TestHandler import TestHandler
-from Gui.GUIutils.settings import ModuleLaneMap
 from Gui.python.logging_config import logger
-from InnerTrackerTests.TestSequences import CompositeTests, Test_to_Ph2ACF_Map
-
+from InnerTrackerTests.TestSequences import CompositeTests
 
 class QtRunWindow(QWidget):
     resized = pyqtSignal()
@@ -208,7 +200,6 @@ class QtRunWindow(QWidget):
         self.ResetButton.clicked.connect(self.resetConfigTest)
         self.RunButton = QPushButton("&Run")
         self.RunButton.setDefault(True)
-        self.RunButton.clicked.connect(lambda: self.ProgressBarLabel.setText(""))
         self.RunButton.clicked.connect(self.resetConfigTest)
         self.RunButton.clicked.connect(self.initialTest)
         self.RunButton.clicked.connect(lambda: self.RunButton.setDisabled(True))
@@ -375,16 +366,26 @@ class QtRunWindow(QWidget):
         self.MainBodyBox.deleteLater()
         self.mainLayout.removeWidget(self.MainBodyBox)
 
+    def upload_to_Panthera_starter(self):
+        self.UploadProgressBar = QProgressBar()
+        self.UploadWheel = LoadingWheel()
+        self.UploadProgressBar.setFormat(f'0/{len(self.testHandler.modules)} uploaded')
+        self.StartLayout.insertWidget(1,self.UploadProgressBar)
+        self.StartLayout.insertWidget(1,self.UploadWheel)
+        self.AppOption.repaint()
+
+        self.Panthera_thread = LoadingThread(self.testHandler.upload_to_Panthera,50)
+        self.Panthera_thread.finished.connect(lambda : self.UploadWheel.close())
+        self.Panthera_thread.timer.timeout.connect(self.UploadWheel.update_spinner)
+        self.Panthera_thread.timer.start()
+        self.Panthera_thread.start()  # Start the thread
+
     def createApp(self):
         self.AppOption = QGroupBox()
         self.StartLayout = QHBoxLayout()
 
-        self.ProgressBarLabel = QLabel("")
-        self.testHandler.uploadBarSignal.connect(lambda counter, nummodules:self.runwindow.ProgressBarLabel.setText("Uploading modules: ["+"##"*int(counter)+"=="*int(nummodules-counter)+"] "+str(counter)+"/"+str(nummodules)))
-
-
         self.UploadButton = QPushButton("&Upload Results")
-        self.UploadButton.clicked.connect(self.testHandler.upload_to_Panthera)
+        self.UploadButton.clicked.connect(self.upload_to_Panthera_starter)
         self.UploadButton.setDisabled(True)
 
         self.BackButton = QPushButton("&Back")
@@ -397,8 +398,6 @@ class QtRunWindow(QWidget):
         self.FinishButton.clicked.connect(self.closeWindow)
 
         self.StartLayout.addStretch(1)
-
-        self.StartLayout.addWidget(self.ProgressBarLabel)
 
         #if self.master.expertMode == True:
         #    self.StartLayout.addWidget(self.UploadButton)
@@ -660,7 +659,7 @@ class QtRunWindow(QWidget):
         except Exception as err:
             logger.error(err)
 
-    def updateRampBar(self, bar:QProgressBar, value:int, text:str):
+    def updateProgressBar(self, bar:QProgressBar, value:int, text:str):
         bar.setFormat(text)
         bar.setValue(value)
 
@@ -698,7 +697,7 @@ class QtRunWindow(QWidget):
             reply = QMessageBox.question(
                 self,
                 "Window Close",
-                "Are you sure you want to quit the test? runwin",
+                "Are you sure you want to quit the test?",
                 QMessageBox.No | QMessageBox.Yes,
                 QMessageBox.No,
             )
@@ -714,7 +713,6 @@ class QtRunWindow(QWidget):
                     QMessageBox.information(self, "Info", "You must turn off "
                                             "instruments manually",
                                             QMessageBox.Ok)
-                #if hasattr(self.testHandler, "fail_window"): self.testHandler.fail_window.close()
                 event.accept()
             else:
                 self.backSignal = False

--- a/Gui/QtGUIutils/QtRunWindow.py
+++ b/Gui/QtGUIutils/QtRunWindow.py
@@ -16,6 +16,7 @@ from PyQt5.QtWidgets import (
     QWidget,
     QMessageBox,
     QSplitter,
+    QProgressBar
 )
 
 import os
@@ -71,7 +72,8 @@ class QtRunWindow(QWidget):
             assert self.master.instruments is not None, logger.error("Unable to setup instruments")
             self.testHandler.powerSignal.connect(
                 lambda: self.master.instruments.off(
-                    hv_delay=0.3, hv_step_size=10, measure=False
+                    hv_delay=0.3, hv_step_size=10, measure=False,
+                    execute_each_step=lambda:self.testHandler.ramp_progress_bar(False,10,None)
                 )
             )
 
@@ -131,8 +133,8 @@ class QtRunWindow(QWidget):
         self.setLoginUI()
         # self.initializeRD53Dict()
         self.createHeadLine()
-        self.createMain()
         self.createApp()
+        self.createMain()
         self.occupied()
 
         self.resized.connect(self.rescaleImage)
@@ -270,6 +272,7 @@ class QtRunWindow(QWidget):
         # self.ConsoleView.setCenterOnScroll(True)
         self.ConsoleView.ensureCursorVisible()
         self.ConsoleView.setReadOnly(True)
+        self.ConsoleView_html = ""
 
         ConsoleLayout.addWidget(self.ConsoleView)
         TerminalBox.setLayout(ConsoleLayout)
@@ -321,11 +324,24 @@ class QtRunWindow(QWidget):
         self.TempLayout.addWidget(self.tempIndicator, 1, 1, 1, 1)
         self.TempBox.setLayout(self.TempLayout)
 
+        self.RampBox = QGroupBox()
+        self.RampLayout = QGridLayout()
+        self.RampProgressBars = [QProgressBar()]*len(self.master.instruments._module_dict.values())
+        RampProgressLabels = [QLabel("Bias Voltage:")]*len(self.master.instruments._module_dict.values())
+        for label in RampProgressLabels: label.setStyleSheet("font-weight: bold;")
+        
+        for i in range(len(self.master.instruments._module_dict.values())):
+            self.RampLayout.addWidget(RampProgressLabels[i], i, 0, 1, 1)
+            self.RampLayout.addWidget(self.RampProgressBars[i], i, 1, 1, 1)
+        self.RampBox.setLayout(self.RampLayout)
+
         LeftColSplitter.addWidget(ControllerBox)
         LeftColSplitter.addWidget(TerminalBox)
+        LeftColSplitter.addWidget(self.RampBox)
         LeftColSplitter.addWidget(self.TempBox)
         RightColSplitter.addWidget(OutputBox)
         RightColSplitter.addWidget(self.HistoryBox)
+        RightColSplitter.addWidget(self.AppOption)
 
         LeftColSplitterSP = LeftColSplitter.sizePolicy()
         LeftColSplitterSP.setHorizontalStretch(self.HorizontalSeg[0])
@@ -363,6 +379,8 @@ class QtRunWindow(QWidget):
         self.StartLayout = QHBoxLayout()
 
         self.ProgressBarLabel = QLabel("")
+        self.testHandler.uploadBarSignal.connect(lambda counter, nummodules:self.runwindow.ProgressBarLabel.setText("Uploading modules: ["+"##"*int(counter)+"=="*int(nummodules-counter)+"] "+str(counter)+"/"+str(nummodules)))
+
 
         self.UploadButton = QPushButton("&Upload Results")
         self.UploadButton.clicked.connect(self.testHandler.upload_to_Panthera)
@@ -412,16 +430,14 @@ class QtRunWindow(QWidget):
 
         self.LogoGroupBox.setLayout(self.LogoLayout)
 
-        self.mainLayout.addWidget(
-            self.AppOption, sum(self.GroupBoxSeg[0:2]), 0, self.GroupBoxSeg[2], 1
-        )
+        #self.mainLayout.addWidget(self.AppOption, sum(self.GroupBoxSeg[0:2]), 0, self.GroupBoxSeg[2], )
         self.mainLayout.addWidget(
             self.LogoGroupBox, sum(self.GroupBoxSeg[0:3]), 0, self.GroupBoxSeg[2], 1
         )
 
     def destroyApp(self):
         self.AppOption.deleteLater()
-        self.mainLayout.removeWidget(self.AppOption)
+        #self.mainLayout.removeWidget(self.AppOption)
 
     def closeWindow(self):
         self.close()
@@ -434,7 +450,19 @@ class QtRunWindow(QWidget):
         self.master.ProcessingTest = True
 
     def release(self):
-        self.testHandler.abortTest()
+        self.testHandler.halt = False
+        print(0)
+        self.testHandler.run_process.kill()
+        print(1)
+
+        self.testHandler.starttime = None
+        if self.testHandler.IVCurveHandler:
+            self.testHandler.outputString.emit("Aborting IVCurve")
+            self.testHandler.IVCurveHandler.stop()
+        if self.testHandler.SLDOScanHandler:
+            self.testHandler.outputString.emit("Aborting SLDOScan")
+            self.testHandler.SLDOScanHandler.stop()
+
         self.master.ProcessingTest = False
         if self.master.expertMode == True:
             self.master.NewTestButton.setDisabled(False)
@@ -631,6 +659,10 @@ class QtRunWindow(QWidget):
         except Exception as err:
             logger.error(err)
 
+    def updateRampBar(self, bar:QProgressBar, value:int, text:str):
+        bar.setFormat(text)
+        bar.setValue(value)
+
     #######################################################################
     ##  For real-time terminal display
     #######################################################################
@@ -665,7 +697,7 @@ class QtRunWindow(QWidget):
             reply = QMessageBox.question(
                 self,
                 "Window Close",
-                "Are you sure you want to quit the test?",
+                "Are you sure you want to quit the test? runwin",
                 QMessageBox.No | QMessageBox.Yes,
                 QMessageBox.No,
             )
@@ -674,14 +706,14 @@ class QtRunWindow(QWidget):
                 self.release()
                 if self.master.instruments:
                     self.master.instruments.off(
-                        hv_delay=0.3, hv_step_size=10
+                        hv_delay=0.3, hv_step_size=10, execute_each_step=lambda:self.testHandler.ramp_progress_bar(False,10,None)
                     )
                 else:
                     QMessageBox.information(self, "Info", "You must turn off "
                                             "instruments manually",
                                             QMessageBox.Ok)
+                #if hasattr(self.testHandler, "fail_window"): self.testHandler.fail_window.close()
                 event.accept()
-                if hasattr(self.testHandler, "fail_window"): self.testHandler.fail_window.close()
             else:
                 self.backSignal = False
                 event.ignore()

--- a/Gui/QtGUIutils/QtRunWindow.py
+++ b/Gui/QtGUIutils/QtRunWindow.py
@@ -434,7 +434,7 @@ class QtRunWindow(QWidget):
         self.master.ProcessingTest = True
 
     def release(self):
-        self.testhandler.abortTest()
+        self.testHandler.abortTest()
         self.master.ProcessingTest = False
         if self.master.expertMode == True:
             self.master.NewTestButton.setDisabled(False)

--- a/Gui/QtGUIutils/QtRunWindow.py
+++ b/Gui/QtGUIutils/QtRunWindow.py
@@ -3,7 +3,6 @@ from PyQt5.QtGui import QPixmap, QColor, QImage
 from PyQt5.QtWidgets import (
     QAbstractItemView,
     QCheckBox,
-    QDialog,
     QGridLayout,
     QGroupBox,
     QHBoxLayout,
@@ -19,10 +18,8 @@ from PyQt5.QtWidgets import (
     QProgressBar
 )
 
-import os
+import os, numpy as np
 import threading
-import time
-import logging
 import Gui.siteSettings as site_settings
 
 from Gui.GUIutils.DBConnection import checkDBConnection
@@ -70,12 +67,8 @@ class QtRunWindow(QWidget):
         self.testHandler = TestHandler(self, master, info, firmware)
         if not site_settings.manual_powersupply_control:
             assert self.master.instruments is not None, logger.error("Unable to setup instruments")
-            self.testHandler.powerSignal.connect(
-                lambda: self.master.instruments.off(
-                    hv_delay=0.3, hv_step_size=10, measure=False,
-                    execute_each_step=lambda:self.testHandler.ramp_progress_bar(False,10,None)
-                )
-            )
+
+            self.testHandler.powerSignal.connect(lambda: self.onPowerSignal)
 
         self.GroupBoxSeg = [1, 10, 1]
         self.HorizontalSeg = [3, 5]
@@ -138,6 +131,14 @@ class QtRunWindow(QWidget):
         self.occupied()
 
         self.resized.connect(self.rescaleImage)
+
+    
+    def onPowerSignal(self):
+        starting_voltages = [int(np.abs(int(getattr(module["hv"], "voltage")))) for module in self.master.instruments._module_dict.values()]
+        self.master.instruments.off(
+                hv_delay=0.3, hv_step_size=10, measure=False,
+                execute_each_step=lambda:self.testHandler.ramp_progress_bar(starting_voltages)
+            )
 
     def setLoginUI(self):
         X = self.master.dimension.width() / 10
@@ -451,9 +452,9 @@ class QtRunWindow(QWidget):
 
     def release(self):
         self.testHandler.halt = False
-        print(0)
+        print('err1')
         self.testHandler.run_process.kill()
-        print(1)
+        print('err2')
 
         self.testHandler.starttime = None
         if self.testHandler.IVCurveHandler:
@@ -705,8 +706,10 @@ class QtRunWindow(QWidget):
             if reply == QMessageBox.Yes:
                 self.release()
                 if self.master.instruments:
+                    starting_voltages = [np.abs(getattr(module["hv"], "voltage")) for module in self.master.instruments._module_dict.values()]
+                    print(1)
                     self.master.instruments.off(
-                        hv_delay=0.3, hv_step_size=10, execute_each_step=lambda:self.testHandler.ramp_progress_bar(False,10,None)
+                        hv_delay=0.3, hv_step_size=10, execute_each_step=lambda:self.testHandler.ramp_progress_bar(starting_voltages)
                     )
                 else:
                     QMessageBox.information(self, "Info", "You must turn off "

--- a/Gui/QtGUIutils/QtRunWindow.py
+++ b/Gui/QtGUIutils/QtRunWindow.py
@@ -70,7 +70,6 @@ class QtRunWindow(QWidget):
         self.DisplayW = self.width() * 3.0 / 7
 
         self.processingFlag = False
-        self.ProgressBarList = []
         self.input_dir = ""
         self.output_dir = ""
         self.config_file = (
@@ -203,13 +202,8 @@ class QtRunWindow(QWidget):
         self.RunButton.clicked.connect(self.resetConfigTest)
         self.RunButton.clicked.connect(self.initialTest)
         self.RunButton.clicked.connect(lambda: self.RunButton.setDisabled(True))
-        # self.RunButton.clicked.connect(self.runTest)
-        # self.ContinueButton = QPushButton("&Continue")
-        # self.ContinueButton.clicked.connect(self.sendProceedSignal)
         self.AbortButton = QPushButton("&Abort")
         self.AbortButton.clicked.connect(self.abortTest)
-        # self.SaveButton = QPushButton("&Save")
-        # self.SaveButton.clicked.connect(self.saveTest)
         self.saveCheckBox = QCheckBox("&auto-save to Panthera")
         self.saveCheckBox.setMaximumHeight(30)
         if self.master.panthera_connected:
@@ -219,20 +213,7 @@ class QtRunWindow(QWidget):
             self.testHandler.autoSave = False
             self.saveCheckBox.setChecked(False)
             self.saveCheckBox.setDisabled(True)
-        # if not isActive(self.connection):
-        #     self.saveCheckBox.setChecked(False)
-        #     self.testHandler.autoSave = False
-        #     self.saveCheckBox.setDisabled(True)
-        
-        ##### previous layout ##########
-        """
 
-		self.ControlLayout.addWidget(self.CustomizedButton,0,0,1,2)
-		self.ControlLayout.addWidget(self.ResetButton,0,2,1,1)
-		self.ControlLayout.addWidget(self.RunButton,1,0,1,1)
-		self.ControlLayout.addWidget(self.AbortButton,1,1,1,1)
-		self.ControlLayout.addWidget(self.saveCheckBox,1,2,1,1)
-		"""
         if self.master.expertMode == True:
             self.ControlLayout.addWidget(self.RunButton, 0, 0, 1, 1)
             self.ControlLayout.addWidget(self.AbortButton, 0, 1, 1, 1)
@@ -241,14 +222,10 @@ class QtRunWindow(QWidget):
 
         else:
             pass
-        # 	self.ControlLayout.addWidget(self.RunButton,0,0,1,1)
-        # 	self.ControlLayout.addWidget(self.AbortButton,0,1,1,1)
-        # 	self.saveCheckBox.setDisabled(True)
-        # 	self.ControlLayout.addWidget(self.saveCheckBox,0,2,1,1)
 
         ControllerBox.setLayout(self.ControlLayout)
 
-        # Group Box for ternimal display
+        # Group Box for terminal display
         TerminalBox = QGroupBox("&Terminal")
         TerminalSP = TerminalBox.sizePolicy()
         TerminalSP.setVerticalStretch(self.VerticalSegCol0[1])
@@ -257,16 +234,16 @@ class QtRunWindow(QWidget):
 
         ConsoleLayout = QGridLayout()
 
-        self.ConsoleView = QPlainTextEdit()
-        self.ConsoleView.setStyleSheet(
-            "QTextEdit { background-color: rgb(10, 10, 10); color : white; }"
-        )
-        # self.ConsoleView.setCenterOnScroll(True)
-        self.ConsoleView.ensureCursorVisible()
-        self.ConsoleView.setReadOnly(True)
-        self.ConsoleView_html = ""
+        self.ConsoleViews = [QPlainTextEdit() for i in range(len(self.firmware))]
+        for i in range(len(self.ConsoleViews)):
+            self.ConsoleViews[i].setStyleSheet(
+                "QTextEdit { background-color: rgb(10, 10, 10); color : white; }"
+            )
+            self.ConsoleViews[i].ensureCursorVisible()
+            self.ConsoleViews[i].setReadOnly(True)
+            ConsoleLayout.addWidget(QLabel(self.firmware[i].getBoardName()),0,i)
+            ConsoleLayout.addWidget(self.ConsoleViews[i],1,i)
 
-        ConsoleLayout.addWidget(self.ConsoleView)
         TerminalBox.setLayout(ConsoleLayout)
 
         # Group Box for output display
@@ -347,10 +324,6 @@ class QtRunWindow(QWidget):
         MainSplitter.addWidget(RightColSplitter)
 
         mainbodylayout.addWidget(MainSplitter)
-        # mainbodylayout.addWidget(ControllerBox, sum(self.VerticalSegCol0[:0]), sum(self.HorizontalSeg[:0]), self.VerticalSegCol0[0], self.HorizontalSeg[0])
-        # mainbodylayout.addWidget(TerminalBox, sum(self.VerticalSegCol0[:1]), sum(self.HorizontalSeg[:0]), self.VerticalSegCol0[1], self.HorizontalSeg[0])
-        # mainbodylayout.addWidget(OutputBox, sum(self.VerticalSegCol1[:0]), sum(self.HorizontalSeg[:1]), self.VerticalSegCol1[0], self.HorizontalSeg[1])
-        # mainbodylayout.addWidget(HistoryBox, sum(self.VerticalSegCol1[:1]), sum(self.HorizontalSeg[:1]), self.VerticalSegCol1[1], self.HorizontalSeg[1])
 
         self.MainBodyBox.setLayout(mainbodylayout)
         self.mainLayout.addWidget(
@@ -375,7 +348,7 @@ class QtRunWindow(QWidget):
         self.AppOption.repaint()
 
         self.Panthera_thread = LoadingThread(self.testHandler.upload_to_Panthera,50)
-        self.Panthera_thread.finished.connect(lambda : self.UploadWheel.close())
+        self.Panthera_thread.finished.connect(self.UploadWheel.close)
         self.Panthera_thread.timer.timeout.connect(self.UploadWheel.update_spinner)
         self.Panthera_thread.timer.start()
         self.Panthera_thread.start()  # Start the thread
@@ -450,19 +423,7 @@ class QtRunWindow(QWidget):
         self.master.ProcessingTest = True
 
     def release(self):
-        self.testHandler.halt = False
-
-        self.testHandler.run_process.kill()
-
-
-        self.testHandler.starttime = None
-        if self.testHandler.IVCurveHandler:
-            self.testHandler.outputString.emit("Aborting IVCurve")
-            self.testHandler.IVCurveHandler.stop()
-        if self.testHandler.SLDOScanHandler:
-            self.testHandler.outputString.emit("Aborting SLDOScan")
-            self.testHandler.SLDOScanHandler.stop()
-
+        self.testHandler.abortTest()
         self.master.ProcessingTest = False
         if self.master.expertMode == True:
             self.master.NewTestButton.setDisabled(False)
@@ -508,6 +469,7 @@ class QtRunWindow(QWidget):
                             QColor(Qt.red)
                         )
 
+        self.StatusTable.resizeColumnsToContents()
         self.HistoryLayout.addWidget(self.StatusTable)
 
     def displayTestResultPopup(self, item):
@@ -607,10 +569,10 @@ class QtRunWindow(QWidget):
     ##  For real-time terminal display
     #######################################################################
 
-    def updateConsoleInfo(self, text):
-        textCursor = self.ConsoleView.textCursor()
-        self.ConsoleView.setTextCursor(textCursor)
-        self.ConsoleView.appendHtml(text)
+    def updateConsoleInfo(self, text:str, console:QPlainTextEdit):
+        textCursor = console.textCursor()
+        console.setTextCursor(textCursor)
+        console.appendHtml(text)
 
     def finish(self, EnableReRun):
         self.RunButton.setDisabled(True)
@@ -624,16 +586,13 @@ class QtRunWindow(QWidget):
                 self.UploadButton.setDisabled(self.testHandler.autoSave)
 
     def updateResult(self, newResult):
-        # self.ResultWidget.updateResult("/Users/czkaiweb/Research/data")
         if self.master.expertMode:
             self.ResultWidget.updateResult(newResult)
         else:
-            #self.ResultWidget.updateResult(newResult)
             step, displayDict = newResult
             self.ResultWidget.updateDisplayList(step, displayDict)
 
     def updateIVResult(self, newResult):
-        # self.ResultWidget.updateResult("/Users/czkaiweb/Research/data")
         if self.master.expertMode:
             self.ResultWidget.updateIVResult(newResult)
         else:

--- a/Gui/QtGUIutils/QtStartWindow.py
+++ b/Gui/QtGUIutils/QtStartWindow.py
@@ -497,7 +497,7 @@ class QtStartWindow(QWidget):
             reply = QMessageBox.question(
                 self,
                 "Window Close",
-                "Are you sure you want to quit the test? startwin",
+                "Are you sure you want to quit the test?",
                 QMessageBox.Yes | QMessageBox.No,
                 QMessageBox.No,
             )

--- a/Gui/QtGUIutils/QtStartWindow.py
+++ b/Gui/QtGUIutils/QtStartWindow.py
@@ -50,7 +50,7 @@ import subprocess
 import time
 
 from Gui.QtGUIutils.QtRunWindow import QtRunWindow
-from Gui.QtGUIutils.Loading import LoadingThread, LoadingThread
+from Gui.QtGUIutils.Loading import LoadingThread
 from Gui.QtGUIutils.QtFwCheckDetails import QtFwCheckDetails
 #from Gui.QtGUIutils.QtApplication import *
 from Gui.python.CustomizedWidget import BeBoardBox
@@ -454,9 +454,7 @@ class QtStartWindow(QWidget):
 
         for module in self.BeBoardWidget.getModules():
             if module.getSerialNumber() == "":
-                QMessageBox.information(
-                    self.errorMessageBoxSignal.emit("No valid serial number!",)
-                )
+                self.errorMessageBoxSignal.emit("No valid serial number!",) #Needs to be in a signal or QThread throws an error
                 return
             if module.getFMCPort() == "":
                 self.errorMessageBoxSignal.emit("No valid ID!")
@@ -471,7 +469,7 @@ class QtStartWindow(QWidget):
         for fw in self.firmwareDescription:
             self.checkFwPar(fw.getBoardName())
         if self.passCheck == False:
-            reply = QMessageBox().question(
+            reply = QMessageBox().question( #For some reason this isn't an issue for QThread
                 None,
                 "Error",
                 "Front-End parameter check failed, forced to continue?",
@@ -488,8 +486,8 @@ class QtStartWindow(QWidget):
         
         self.runFlag = True
         self.master.BeBoardWidget = self.BeBoardWidget
-        #self.openRunWindowSignal.emit()
-        #self.close()
+        self.openRunWindowSignal.emit()
+        self.close()
 
     def closeEvent(self, event):
         if self.runFlag == True:

--- a/Gui/QtGUIutils/QtStartWindow.py
+++ b/Gui/QtGUIutils/QtStartWindow.py
@@ -497,7 +497,7 @@ class QtStartWindow(QWidget):
             reply = QMessageBox.question(
                 self,
                 "Window Close",
-                "Are you sure you want to quit the test?",
+                "Are you sure you want to quit the test? startwin",
                 QMessageBox.Yes | QMessageBox.No,
                 QMessageBox.No,
             )

--- a/Gui/QtGUIutils/QtStartWindow.py
+++ b/Gui/QtGUIutils/QtStartWindow.py
@@ -10,7 +10,7 @@ logging.basicConfig(
 
 logger = logging.getLogger(__name__)
 
-from PyQt5.QtCore import QSize, Qt, pyqtSignal
+from PyQt5.QtCore import QSize, Qt, pyqtSignal, QThread
 from PyQt5.QtGui import QPixmap, QImage
 from PyQt5.QtWidgets import (
     QApplication,
@@ -50,7 +50,7 @@ import subprocess
 import time
 
 from Gui.QtGUIutils.QtRunWindow import QtRunWindow
-from Gui.QtGUIutils.Loading import LoadingThread
+from Gui.QtGUIutils.Loading import LoadingThread, LoadingThread
 from Gui.QtGUIutils.QtFwCheckDetails import QtFwCheckDetails
 #from Gui.QtGUIutils.QtApplication import *
 from Gui.python.CustomizedWidget import BeBoardBox
@@ -260,6 +260,7 @@ class SummaryBox(QWidget):
 
 class QtStartWindow(QWidget):
     openRunWindowSignal = pyqtSignal()
+    errorMessageBoxSignal = pyqtSignal(str)
     def __init__(self, master, firmware):
         super(QtStartWindow, self).__init__()
         self.master = master
@@ -275,6 +276,15 @@ class QtStartWindow(QWidget):
         self.occupied()
         self.loading_counter = 0
         self.openRunWindowSignal.connect(self.openRunWindowGUI)
+
+        self.errorMessageBoxSignal.connect( lambda message :
+            QMessageBox.information(
+                None,
+                "Error",
+                message,
+                QMessageBox.Ok,
+            )
+        )
 
     def openRunWindowGUI(self):
         self.master.RunNewTest = QtRunWindow(
@@ -425,9 +435,10 @@ class QtStartWindow(QWidget):
     def openRunWindow_starter(self):
         self.NextButton.setText(". . .")
         self.run_window_thread = LoadingThread(self.openRunWindow,500)
+        self.run_window_thread.finished.connect(lambda : self.NextButton.setText("&Next"))
         self.run_window_thread.timer.timeout.connect(self.loader)
         self.run_window_thread.timer.start()
-        self.run_window_thread.start()  # Start the thread
+        self.run_window_thread.start()
 
     def openRunWindow(self):
         # if not os.access(os.environ.get('GUI_dir'),os.W_OK):
@@ -444,22 +455,17 @@ class QtStartWindow(QWidget):
         for module in self.BeBoardWidget.getModules():
             if module.getSerialNumber() == "":
                 QMessageBox.information(
-                    None, "Error", "No valid serial number!", QMessageBox.Ok
+                    self.errorMessageBoxSignal.emit("No valid serial number!",)
                 )
                 return
             if module.getFMCPort() == "":
-                QMessageBox.information(None, "Error", "No valid ID!", QMessageBox.Ok)
+                self.errorMessageBoxSignal.emit("No valid ID!")
                 return
 
         self.firmwareDescription, message = self.BeBoardWidget.getFirmwareDescription()
         
         if not self.firmwareDescription: #firmware description returns none if no modules are entered
-            QMessageBox.information(
-                None,
-                "Error",
-                message,
-                QMessageBox.Ok,
-            )
+            self.errorMessageBoxSignal.emit(message)
             return
 
         for fw in self.firmwareDescription:
@@ -482,9 +488,8 @@ class QtStartWindow(QWidget):
         
         self.runFlag = True
         self.master.BeBoardWidget = self.BeBoardWidget
-        self.openRunWindowSignal.emit()
-        self.run_window_thread.timer.stop()
-        self.close()
+        #self.openRunWindowSignal.emit()
+        #self.close()
 
     def closeEvent(self, event):
         if self.runFlag == True:

--- a/Gui/QtGUIutils/QtuDTCDialog.py
+++ b/Gui/QtGUIutils/QtuDTCDialog.py
@@ -94,7 +94,7 @@ class QtuDTCDialog(QDialog):
 
     def fetchFPGAConfigs(self):
         try:
-            InputFile = os.environ.get("PH2ACF_BASE_DIR") + "/settings/CMSIT.xml"
+            InputFile = os.environ.get("PH2ACF_BASE_DIR") + f"/settings/CMSIT_{self.module[1].getBoardName()}.xml"
             root, tree = LoadXML(InputFile)
             fwIP = self.module.getIPAddress()
             changeMade = False
@@ -157,7 +157,7 @@ class QtuDTCDialog(QDialog):
             [
                 "fpgaconfig",
                 "-c",
-                os.environ.get("PH2ACF_BASE_DIR") + "/settings/CMSIT.xml.gui",
+                os.environ.get("PH2ACF_BASE_DIR") + f"/settings/CMSIT_{self.module[1].getBoardName()}.xml.gui",
                 "-i",
                 self.uDTCFile,
             ],

--- a/Gui/QtGUIutils/TessieCoolingApp.py
+++ b/Gui/QtGUIutils/TessieCoolingApp.py
@@ -13,16 +13,18 @@ class Tessie(QWidget):
         self.gridLayout = QtWidgets.QGridLayout(self)
 
         self.upperWidget = QWidget()
-        self.upperGridLayout = QtWidgets.QGridLayout(self)
+        self.upperGridLayout = QtWidgets.QGridLayout(self.upperWidget)  # Set layout here
         self.upperWidget.setLayout(self.upperGridLayout)
 
         self.lowerWidget = QWidget()
-        self.lowerGridLayout = QtWidgets.QGridLayout(self)
+        self.lowerGridLayout = QtWidgets.QGridLayout(self.lowerWidget)  # Set layout here
         self.lowerWidget.setLayout(self.lowerGridLayout)
 
         self.gridLayout.addWidget(self.upperWidget, 0, 0)
         self.upperGridLayout.addItem(QtWidgets.QSpacerItem(0, 10))
         self.gridLayout.addWidget(self.lowerWidget, 1, 0)
+
+        self.setLayout(self.gridLayout)  # Set layout for the main window
 
         self.TessieLabel = QtWidgets.QLabel("TESSIE (2024/06/19-06)")
         self.CANbus_errors_label = QtWidgets.QLabel("CANbus errors")

--- a/Gui/python/Firmware.py
+++ b/Gui/python/Firmware.py
@@ -54,12 +54,14 @@ class QtChip:
 
 
 class QtModule:
-    def __init__(self, moduleName = "", moduleType = "", moduleVersion = "", FMCPort = ""):
+    def __init__(self, moduleName = "", moduleType = "", moduleVersion = "", FMCPort = "", enabled = "1", Fc7 = None):
         self.__moduleName = moduleName
         self.__moduleType = moduleType
         self.__moduleVersion = moduleVersion
         self.__FMCPort = FMCPort
         self.__chipDict = {} #{ChipID : QtChip()}, deviates from pattern to make usage easier, laneID is not commonly used
+        self.__enabled = enabled
+        self.__Fc7 = Fc7
         
         if self.__moduleType != "":
             #if module type was specified, initialize chips to default
@@ -112,6 +114,18 @@ class QtModule:
     
     def getEnabledChips(self):
         return {chipID : chip for chipID, chip in self.__chipDict.items() if chip.getStatus()}
+    
+    def setEnabled(self, enabled:str):
+        self.__enabled = enabled
+
+    def getEnabled(self) -> str:
+        return self.__enabled
+    
+    def setFc7(self, Fc7) -> None:
+        self.__Fc7 = Fc7
+    
+    def getFc7(self):
+        return self.__Fc7
     
     """
     These two functions define the parent object accessible from the current object. It's a shortcut

--- a/Gui/python/IVCurveHandler.py
+++ b/Gui/python/IVCurveHandler.py
@@ -1,9 +1,6 @@
-from PyQt5 import QtCore
-from PyQt5.QtCore import QThread, QObject, pyqtSignal, QProcess
+from PyQt5.QtCore import QThread, QObject, pyqtSignal
 
-import os
-import time
-import numpy
+import numpy as np
 from Gui.python.logging_config import logger
 from Gui.siteSettings import IVcurve_range
 
@@ -36,7 +33,8 @@ class IVCurveThread(QThread):
         self.turnOn()
 
     def turnOn(self):
-        self.instruments.hv_off(execute_each_step=lambda : self.execute_each_step(False, None, (getattr(module["hv"], "voltage") for module in self.instruments._module_dict.values()) ))
+        starting_voltages = [np.abs(getattr(module["hv"], "voltage")) for module in self.instruments._module_dict.values()]
+        self.instruments.hv_off(execute_each_step=lambda:self.execute_each_step(starting_voltages))
         self.instruments.hv_on(voltage=0, delay=0.5, step_size=10, no_lock=True)
         self.instruments.hv_set_ocp(0.00001)
 
@@ -56,7 +54,8 @@ class IVCurveThread(QThread):
 
     def run(self):
         try:
-            self.instruments.hv_off(execute_each_step=lambda : self.execute_each_step(False, self.step_size, (getattr(module["hv"], "voltage") for module in self.instruments._module_dict.values()) ))
+            starting_voltages = [np.abs(getattr(module["hv"], "voltage")) for module in self.instruments._module_dict.values()]
+            self.instruments.hv_off(execute_each_step=lambda : self.execute_each_step(starting_voltages))
             #self.run_process = QProcess(self)
             #self.run_process.setProcessChannelMode(QProcess.MergedChannels)
             #self.run_process.setWorkingDirectory(
@@ -102,11 +101,10 @@ class IVCurveHandler(QObject):
     progressSignal = pyqtSignal(str, float)
     startSignal = pyqtSignal()
 
-    def __init__(self, instrument_cluster, execute_each_step, ramp_down_step_size=5):
+    def __init__(self, instrument_cluster, execute_each_step):
         super(IVCurveHandler, self).__init__()
         self.instruments = instrument_cluster
         self.execute_each_step = execute_each_step
-        self.step_size = ramp_down_step_size
 
         assert self.instruments is not None, logger.debug("Error instantiating instrument cluster")
 
@@ -129,14 +127,15 @@ class IVCurveHandler(QObject):
         self.progressSignal.emit(measurementType, percentStep)
 
     def finish(self, test: str, measure: dict):
-        self.instruments.hv_off(step_size=self.step_size, execute_each_step=lambda : self.execute_each_step(False, self.step_size, (getattr(module["hv"], "voltage") for module in self.instruments._module_dict.values()) ))
+        starting_voltages = [np.abs(getattr(module["hv"], "voltage")) for module in self.instruments._module_dict.values()]
+        self.instruments.hv_off(step_size=5, execute_each_step=lambda : self.execute_each_step(starting_voltages))
         self.finished.emit(test, measure)
-
 
     def stop(self):
         try:
             self.test.abortTest()
-            self.instruments.hv_off(no_lock=True, step_size=self.step_size, execute_each_step=lambda : self.execute_each_step(False, self.step_size, (getattr(module["hv"], "voltage") for module in self.instruments._module_dict.values())))
+            starting_voltages = [np.abs(getattr(module["hv"], "voltage")) for module in self.instruments._module_dict.values()]
+            self.instruments.hv_off(no_lock=True, step_size=5, execute_each_step=lambda : self.execute_each_step(starting_voltages))
             self.test.terminate()
         except Exception as err:
             print(f"Failed to stop the IV test due to error {err}")

--- a/Gui/python/IVCurveHandler.py
+++ b/Gui/python/IVCurveHandler.py
@@ -13,7 +13,7 @@ class IVCurveThread(QThread):
     measureSignal = pyqtSignal(str, object)
     progressSignal = pyqtSignal(str, float)
 
-    def __init__(self, parent, instrument_cluster=None):
+    def __init__(self, parent, instrument_cluster=None, execute_each_step=lambda:None):
         super(IVCurveThread, self).__init__()
         self.instruments = instrument_cluster
         self.parent = parent
@@ -21,6 +21,7 @@ class IVCurveThread(QThread):
         self.progressSignal.connect(self.parent.transmitProgress) #FIXME add slot function
         self.exiting = False
         self.setTerminationEnabled(True)
+        self.execute_each_step = execute_each_step
 
         self.startVal = 0
         self.target = 0
@@ -35,7 +36,7 @@ class IVCurveThread(QThread):
         self.turnOn()
 
     def turnOn(self):
-        self.instruments.hv_off()
+        self.instruments.hv_off(execute_each_step=lambda : self.execute_each_step(False, None, (getattr(module["hv"], "voltage") for module in self.instruments._module_dict.values()) ))
         self.instruments.hv_on(voltage=0, delay=0.5, step_size=10, no_lock=True)
         self.instruments.hv_set_ocp(0.00001)
 
@@ -48,13 +49,14 @@ class IVCurveThread(QThread):
     def getProgress(self):
         self.percentStep = abs(100*self.stepLength/self.stopVal)
         self.progressSignal.emit("IVCurve", self.percentStep)
+        
 
     def abortTest(self):
         self.exiting = True
 
     def run(self):
         try:
-            self.instruments.hv_off()
+            self.instruments.hv_off(execute_each_step=lambda : self.execute_each_step(False, self.step_size, (getattr(module["hv"], "voltage") for module in self.instruments._module_dict.values()) ))
             #self.run_process = QProcess(self)
             #self.run_process.setProcessChannelMode(QProcess.MergedChannels)
             #self.run_process.setWorkingDirectory(
@@ -68,7 +70,7 @@ class IVCurveThread(QThread):
             #self.run_process.waitForStarted(1000)
             
             _, measurements = self.instruments.hv_on(
-                voltage= self.stopVal,
+                voltage=self.stopVal,
                 step_size= self.stepLength,
                 delay=0.2,
                 measure=True,
@@ -100,14 +102,15 @@ class IVCurveHandler(QObject):
     progressSignal = pyqtSignal(str, float)
     startSignal = pyqtSignal()
 
-    def __init__(self, instrument_cluster, execute_each_step):
+    def __init__(self, instrument_cluster, execute_each_step, ramp_down_step_size=5):
         super(IVCurveHandler, self).__init__()
         self.instruments = instrument_cluster
         self.execute_each_step = execute_each_step
+        self.step_size = ramp_down_step_size
 
         assert self.instruments is not None, logger.debug("Error instantiating instrument cluster")
 
-        self.test = IVCurveThread(self, instrument_cluster=self.instruments)
+        self.test = IVCurveThread(self, instrument_cluster=self.instruments, execute_each_step=self.execute_each_step)
         self.test.progressSignal.connect(self.transmitProgress)
         self.test.measureSignal.connect(self.finish)
 
@@ -126,14 +129,14 @@ class IVCurveHandler(QObject):
         self.progressSignal.emit(measurementType, percentStep)
 
     def finish(self, test: str, measure: dict):
-        self.instruments.hv_off(execute_each_step=self.execute_each_step)
+        self.instruments.hv_off(step_size=self.step_size, execute_each_step=lambda : self.execute_each_step(False, self.step_size, (getattr(module["hv"], "voltage") for module in self.instruments._module_dict.values()) ))
         self.finished.emit(test, measure)
 
 
     def stop(self):
         try:
             self.test.abortTest()
-            self.instruments.hv_off(no_lock=True)
+            self.instruments.hv_off(no_lock=True, step_size=self.step_size, execute_each_step=lambda : self.execute_each_step(False, self.step_size, (getattr(module["hv"], "voltage") for module in self.instruments._module_dict.values())))
             self.test.terminate()
         except Exception as err:
             print(f"Failed to stop the IV test due to error {err}")

--- a/Gui/python/IVCurveHandler.py
+++ b/Gui/python/IVCurveHandler.py
@@ -56,29 +56,16 @@ class IVCurveThread(QThread):
         try:
             starting_voltages = [np.abs(getattr(module["hv"], "voltage")) for module in self.instruments._module_dict.values()]
             self.instruments.hv_off(execute_each_step=lambda : self.execute_each_step(starting_voltages))
-            #self.run_process = QProcess(self)
-            #self.run_process.setProcessChannelMode(QProcess.MergedChannels)
-            #self.run_process.setWorkingDirectory(
-            #    os.environ.get("PH2ACF_BASE_DIR") + "/test/")
-
-            #self.run_process.start(
-            #    "CMSITminiDAQ",
-            #    ["-f", "CMSIT.xml", "-c",
-            #     "physics"],
-            #)
-            #self.run_process.waitForStarted(1000)
             
             _, measurements = self.instruments.hv_on(
                 voltage=self.stopVal,
                 step_size= self.stepLength,
                 delay=0.2,
                 measure=True,
-                #break_monitoring=self.breakTest,
                 execute_each_step=self.getProgress,
             )[0]
 
             # The physics test can be stopped by pressing enter
-            #self.run_process.write(b"\r\n") 
 
             measurementStr = {
                 "voltage": [value[4] for value in measurements],
@@ -88,11 +75,8 @@ class IVCurveThread(QThread):
             print("Voltages: ", measurementStr["voltage"])
             print("Currents: ", measurementStr["current"])
             self.measureSignal.emit("IVCurve", measurementStr)
-            #self.run_process.write(b"\r\n")
         except Exception as e:
             print("IV Curve scan failed with {}".format(e))
-            #self.run_process.write(b"\r\n")
-
 
 class IVCurveHandler(QObject):
     measureSignal = pyqtSignal(str, object)

--- a/Gui/python/SLDOScanHandler.py
+++ b/Gui/python/SLDOScanHandler.py
@@ -29,6 +29,7 @@ class SLDOCurveWorker(QThread):
         starting_current=1,
         max_voltage=1.8,
         pin_list=[],
+        execute_each_step=lambda:None
     ):
         super().__init__()
         self.instruments = instrument_cluster
@@ -79,10 +80,11 @@ class SLDOCurveWorker(QThread):
                 13: 'VDDD_ROC0',
                 14: 'VDDD_ROC1',
                 # 15: 'TP7A', #VOFS OUT
-                # 16: 'TP7B', #VOFS OUT
+                # 16: 'TP7B', #VOFShv_off OUT
             },
         }
         self.LV_index = -1
+        self.execute_each_step = execute_each_step
 
     def run(self) -> None:
         if "adc_board" in self.instruments._instrument_dict.keys():
@@ -108,7 +110,8 @@ class SLDOCurveWorker(QThread):
         # Initialize a list to store the results
         self.labels = []
         # Turn off instruments
-        self.instruments.hv_off()
+        starting_voltages = [np.abs(getattr(module["hv"], "voltage")) for module in self.instruments._module_dict.values()]
+        self.instruments.hv_off(execute_each_step=lambda : self.execute_each_step(starting_voltages))
         self.instruments.lv_off()
         self.adc_board.__enter__()
         logger.info("Turned off the LV and HV")
@@ -175,7 +178,8 @@ class SLDOCurveWorker(QThread):
         self.result_list = []
         self.labels = []
         # Turn off instruments
-        self.instruments.hv_off()
+        starting_voltages = [np.abs(getattr(module["hv"], "voltage")) for module in self.instruments._module_dict.values()]
+        self.instruments.hv_off(execute_each_step=lambda : self.execute_each_step(starting_voltages))
         self.instruments.lv_off()
         self.multimeter.set("SYSTEM_MODE","REM")
         logger.info('turned off the lv and hv')
@@ -307,12 +311,13 @@ class SLDOCurveHandler(QObject):
     abortSignal = pyqtSignal()
     #measureSignal = pyqtSignal(str, object)
 
-    def __init__(self, instrument_cluster, moduleType, end_current, voltage_limit):
+    def __init__(self, instrument_cluster, moduleType, end_current, voltage_limit, execute_each_step):
         super(SLDOCurveHandler, self).__init__()
         self.instruments = instrument_cluster
         self.end_current = end_current
         self.voltage_limit = voltage_limit
-        self.test = SLDOCurveWorker(self.instruments, moduleType=moduleType, target_current=self.end_current, max_voltage=self.voltage_limit)
+        self.execute_each_step = execute_each_step
+        self.test = SLDOCurveWorker(self.instruments, moduleType=moduleType, target_current=self.end_current, max_voltage=self.voltage_limit, execute_each_step=self.execute_each_step)
         self.test.measure.connect(self.makePlots)
         self.test.progressSignal.connect(self.transmitProgress)
         self.test.finishedSignal.connect(self.finish)
@@ -331,7 +336,8 @@ class SLDOCurveHandler(QObject):
         self.progressSignal.emit(measurementType, percentStep)
 
     def finish(self):
-        self.instruments.hv_off()
+        starting_voltages = [np.abs(getattr(module["hv"], "voltage")) for module in self.instruments._module_dict.values()]
+        self.instruments.hv_off(execute_each_step=lambda : self.execute_each_step(starting_voltages))
         self.instruments.lv_off()
         self.finishedSignal.emit()
 
@@ -341,7 +347,8 @@ class SLDOCurveHandler(QObject):
         if reason:
             print(f"Aborting SLDO Scan. Reason: {reason}")
             try:
-                self.instruments.hv_off()
+                starting_voltages = [np.abs(getattr(module["hv"], "voltage")) for module in self.instruments._module_dict.values()]
+                self.instruments.hv_off(execute_each_step=lambda : self.execute_each_step(starting_voltages))
                 self.instruments.lv_off()
                 self.test.terminate()
                 self.abortSignal.emit()
@@ -349,7 +356,8 @@ class SLDOCurveHandler(QObject):
                 logger.error(f"Failed to stop the SLDO test due to error {err}")
         else:
             try:
-                self.instruments.hv_off()
+                starting_voltages = [np.abs(getattr(module["hv"], "voltage")) for module in self.instruments._module_dict.values()]
+                self.instruments.hv_off(execute_each_step=lambda : self.execute_each_step(starting_voltages))
                 self.instruments.lv_off()
                 self.test.terminate()
             except Exception as err:

--- a/Gui/python/SLDOScanHandler.py
+++ b/Gui/python/SLDOScanHandler.py
@@ -108,7 +108,7 @@ class SLDOCurveWorker(QThread):
         # Initialize a list to store the results
         self.labels = []
         # Turn off instruments
-        self.instruments.hv_off(step_size=self.step_size, execute_each_step=lambda : self.execute_each_step(False, self.step_size, (getattr(module["hv"], "voltage") for module in self.instruments._module_dict.values()) ))
+        self.instruments.hv_off()
         self.instruments.lv_off()
         self.adc_board.__enter__()
         logger.info("Turned off the LV and HV")
@@ -175,7 +175,7 @@ class SLDOCurveWorker(QThread):
         self.result_list = []
         self.labels = []
         # Turn off instruments
-        self.instruments.hv_off(step_size=self.step_size, execute_each_step=lambda : self.execute_each_step(False, self.step_size, (getattr(module["hv"], "voltage") for module in self.instruments._module_dict.values()) ))
+        self.instruments.hv_off()
         self.instruments.lv_off()
         self.multimeter.set("SYSTEM_MODE","REM")
         logger.info('turned off the lv and hv')
@@ -331,7 +331,7 @@ class SLDOCurveHandler(QObject):
         self.progressSignal.emit(measurementType, percentStep)
 
     def finish(self):
-        self.instruments.hv_off(step_size=self.step_size, execute_each_step=lambda : self.execute_each_step(False, self.step_size, (getattr(module["hv"], "voltage") for module in self.instruments._module_dict.values()) ))
+        self.instruments.hv_off()
         self.instruments.lv_off()
         self.finishedSignal.emit()
 
@@ -341,7 +341,7 @@ class SLDOCurveHandler(QObject):
         if reason:
             print(f"Aborting SLDO Scan. Reason: {reason}")
             try:
-                self.instruments.hv_off(step_size=self.step_size, execute_each_step=lambda : self.execute_each_step(False, self.step_size, (getattr(module["hv"], "voltage") for module in self.instruments._module_dict.values()) ))
+                self.instruments.hv_off()
                 self.instruments.lv_off()
                 self.test.terminate()
                 self.abortSignal.emit()
@@ -349,7 +349,7 @@ class SLDOCurveHandler(QObject):
                 logger.error(f"Failed to stop the SLDO test due to error {err}")
         else:
             try:
-                self.instruments.hv_off(step_size=self.step_size, execute_each_step=lambda : self.execute_each_step(False, self.step_size, (getattr(module["hv"], "voltage") for module in self.instruments._module_dict.values()) ))
+                self.instruments.hv_off()
                 self.instruments.lv_off()
                 self.test.terminate()
             except Exception as err:

--- a/Gui/python/SLDOScanHandler.py
+++ b/Gui/python/SLDOScanHandler.py
@@ -108,7 +108,7 @@ class SLDOCurveWorker(QThread):
         # Initialize a list to store the results
         self.labels = []
         # Turn off instruments
-        self.instruments.hv_off()
+        self.instruments.hv_off(step_size=self.step_size, execute_each_step=lambda : self.execute_each_step(False, self.step_size, (getattr(module["hv"], "voltage") for module in self.instruments._module_dict.values()) ))
         self.instruments.lv_off()
         self.adc_board.__enter__()
         logger.info("Turned off the LV and HV")
@@ -175,7 +175,7 @@ class SLDOCurveWorker(QThread):
         self.result_list = []
         self.labels = []
         # Turn off instruments
-        self.instruments.hv_off()
+        self.instruments.hv_off(step_size=self.step_size, execute_each_step=lambda : self.execute_each_step(False, self.step_size, (getattr(module["hv"], "voltage") for module in self.instruments._module_dict.values()) ))
         self.instruments.lv_off()
         self.multimeter.set("SYSTEM_MODE","REM")
         logger.info('turned off the lv and hv')
@@ -331,7 +331,7 @@ class SLDOCurveHandler(QObject):
         self.progressSignal.emit(measurementType, percentStep)
 
     def finish(self):
-        self.instruments.hv_off()
+        self.instruments.hv_off(step_size=self.step_size, execute_each_step=lambda : self.execute_each_step(False, self.step_size, (getattr(module["hv"], "voltage") for module in self.instruments._module_dict.values()) ))
         self.instruments.lv_off()
         self.finishedSignal.emit()
 
@@ -341,7 +341,7 @@ class SLDOCurveHandler(QObject):
         if reason:
             print(f"Aborting SLDO Scan. Reason: {reason}")
             try:
-                self.instruments.hv_off()
+                self.instruments.hv_off(step_size=self.step_size, execute_each_step=lambda : self.execute_each_step(False, self.step_size, (getattr(module["hv"], "voltage") for module in self.instruments._module_dict.values()) ))
                 self.instruments.lv_off()
                 self.test.terminate()
                 self.abortSignal.emit()
@@ -349,7 +349,7 @@ class SLDOCurveHandler(QObject):
                 logger.error(f"Failed to stop the SLDO test due to error {err}")
         else:
             try:
-                self.instruments.hv_off()
+                self.instruments.hv_off(step_size=self.step_size, execute_each_step=lambda : self.execute_each_step(False, self.step_size, (getattr(module["hv"], "voltage") for module in self.instruments._module_dict.values()) ))
                 self.instruments.lv_off()
                 self.test.terminate()
             except Exception as err:

--- a/Gui/python/TestHandler.py
+++ b/Gui/python/TestHandler.py
@@ -1063,7 +1063,7 @@ created by felis is empty.")
                 self.powerSignal.emit()
                 EnableReRun = True
                 if self.autoSave:
-                    self.upload_to_Panthera()
+                    self.runwindow.upload_to_Panthera_starter()
                 if self.info == "FWD-RVS Bias" or self.info == "CrossTalk":
                     self.bumpbond_analysis()
         
@@ -1071,7 +1071,7 @@ created by felis is empty.")
             EnableReRun = True
             self.powerSignal.emit()
             if self.autoSave:
-                self.upload_to_Panthera()
+                self.runwindow.upload_to_Panthera_starter()
 
         self.stepFinished.emit(EnableReRun)
 
@@ -1248,12 +1248,12 @@ created by felis is empty.")
                 self.powerSignal.emit()
                 EnableReRun = True
                 if self.autoSave:
-                    self.upload_to_Panthera()
+                    self.runwindow.upload_to_Panthera_starter()
         elif isSingleTest(self.info):
             EnableReRun = True
             self.powerSignal.emit()
             if self.autoSave:
-                self.upload_to_Panthera()
+                self.runwindow.upload_to_Panthera_starter()
 
         self.stepFinished.emit(EnableReRun)
 
@@ -1304,12 +1304,12 @@ created by felis is empty.")
                 self.powerSignal.emit()
                 EnableReRun = True
                 if self.autoSave:
-                    self.upload_to_Panthera()
+                    self.runwindow.upload_to_Panthera_starter()
         elif isSingleTest(self.info):
             EnableReRun = True
             self.powerSignal.emit()
             if self.autoSave:
-                self.upload_to_Panthera()
+                self.runwindow.upload_to_Panthera_starter()
 
         self.stepFinished.emit(EnableReRun)
 
@@ -1432,7 +1432,7 @@ created by felis is empty.")
                 )
                 if not status:
                     raise ConnectionError(message)
-                
+
                 counter+=1
                 self.updateProgressBar.emit(self.runwindow.UploadProgressBar,
                                         100*counter/len(self.modules),
@@ -1445,7 +1445,7 @@ created by felis is empty.")
             if not self.master.panthera_connected:
                 error_message = "Cannot upload test results, you are not signed in to Panthera."
             else:
-                error_message = repr(e)
+                error_message = "Failed to upload to felis."
                 self.runwindow.UploadButton.setDisabled(False)
                 if self.autoSave:
                     self.runwindow.UploadButton.setDisabled(False) #if autosave fails, allow manual

--- a/Gui/python/TestHandler.py
+++ b/Gui/python/TestHandler.py
@@ -80,11 +80,14 @@ class TestHandler(QObject):
     updateValidation = pyqtSignal(object)
     updateFinishedTests = pyqtSignal(object)
     powerSignal = pyqtSignal()
+    updateRampBar = pyqtSignal(QProgressBar, int, str)
+    uploadBarSignal = pyqtSignal(int, int)
 
     def __init__(self, runwindow, master, info, firmware):
         super(TestHandler, self).__init__()
         self.master = master
         self.instruments = self.master.instruments
+        print(self.instruments)
         self.mod_dict={}
         self.fused_dict_index=[-1,-1]
         # self.LVpowersupply.Reset()
@@ -101,6 +104,7 @@ class TestHandler(QObject):
         self.ModuleMap = dict()
         
         self.modules = [module for beboard in self.firmware for module in beboard.getModules()]
+        self.statuses = {module.getModuleName():"1" for module in self.modules}
         
         self.numChips = len([chipID for module in self.modules for chipID in module.getEnabledChips().keys()])
                 
@@ -188,7 +192,11 @@ class TestHandler(QObject):
         self.updateSLDOResult.connect(self.runwindow.updateSLDOResult)
         self.updateValidation.connect(self.runwindow.updateValidation)
         self.updateFinishedTests.connect(self.runwindow.updateFinishedTests)
+        self.updateRampBar.connect(self.runwindow.updateRampBar)
 
+        self.finished_tests = []
+        self.ramp_counter=1
+        self.current_bar=0
 
         self.initializeRD53Dict()
 
@@ -271,7 +279,7 @@ class TestHandler(QObject):
                     except:
                         logger.warning("Failed to create " + tmpDir)
                 # Create the xml file from the text file
-                config_file = GenerateXMLConfig(self.firmware, self.currentTest, tmpDir)
+                config_file = GenerateXMLConfig(self.firmware, self.currentTest, tmpDir, self.statuses)
 
                 # config_file = os.environ.get('GUI_dir')+ConfigFiles.get(testName, "None")
                 if config_file:
@@ -298,7 +306,7 @@ class TestHandler(QObject):
                         logger.info("Creating " + tmpDir)
                     except:
                         logger.warning("Failed to create " + tmpDir)
-                config_file = GenerateXMLConfig(self.firmware, self.currentTest, tmpDir)
+                config_file = GenerateXMLConfig(self.firmware, self.currentTest, tmpDir, self.statuses)
                 # config_file = os.environ.get('GUI_dir')+ConfigFiles.get(testName, "None")
                 if config_file:
                     SetupXMLConfigfromFile(
@@ -375,18 +383,29 @@ class TestHandler(QObject):
         #    updatedGlobalValue[1] = stepWiseGlobalValue[self.testIndexTracker]
         self.runSingleTest(testName)
 
-    def ramp_down_progress_bar(self):
-        stepLength = self.instruments.default_step_size
-        range = np.abs(int(site_settings.IVcurve_range/stepLength))
-        progressNum = int(30*self.ramp_down_counter/range)
-        loading_bar = f"Ramping Down: [{'#'*progressNum}{'='*(30-progressNum)}]"
-        self.runwindow.ConsoleView.setPlainText(f'{self.console_body}\n{loading_bar}')
-        QApplication.processEvents() #may not be ideal
-        self.ramp_down_counter += 1
+    def ramp_progress_bar(self, rampUp, step_size, voltage): #might be a more elegant way to do this
+        
+        if self.ramp_counter==1 and self.current_bar==0:
+            if rampUp==False: self.sweep_distances = [getattr(module["hv"], "voltage") for module in self.instruments._module_dict.values()]
+
+        step_size = list(self.instruments._module_dict.values())[self.current_bar]["hv"].default_step_size if step_size==None else step_size
+        sweep_distance = voltage if rampUp else self.sweep_distances[self.current_bar]
+        range = np.abs(int(sweep_distance/step_size))
+
+        if self.ramp_counter>range:
+            self.current_bar = (self.current_bar + 1)%len(self.instruments._module_dict.values())
+            self.ramp_counter = 1
+            return
+
+        value = int(100*self.ramp_counter/range if rampUp else 100*(1- (self.ramp_counter/range)))
+        text = f'{step_size*self.ramp_counter} V' if rampUp else f'{np.abs(self.sweep_distances[self.current_bar])-step_size*self.ramp_counter} V'
+        self.updateRampBar.emit(self.runwindow.RampProgressBars[self.current_bar], value, text)
+        self.ramp_counter += 1
 
     def runSingleTest(self, testName):
         print("Executing Single Step test...")
         self.outputString.emit("Executing Single Step test...")
+
         if self.instruments:
             lv_on = False
             for number in self.instruments.get_modules().keys():
@@ -413,9 +432,7 @@ class TestHandler(QObject):
             self.configTest()
             self.IVCurveData = []
             self.IVProgressValue = 0
-            self.console_body = self.runwindow.ConsoleView.toPlainText()
-            self.ramp_down_counter = 1
-            self.IVCurveHandler = IVCurveHandler(self.instruments, self.ramp_down_progress_bar)
+            self.IVCurveHandler = IVCurveHandler(self.instruments, self.ramp_progress_bar)
             self.IVCurveHandler.finished.connect(self.IVCurveFinished)
             self.IVCurveHandler.progressSignal.connect(self.updateProgress)
             self.IVCurveHandler.startSignal.connect(self.setupQProcess)
@@ -430,7 +447,9 @@ class TestHandler(QObject):
             self.SLDOfilelist = []
             self.SLDOProgressValue = 0
             #self.SLDOScanResult = ScanCanvas(self, xlabel="Voltage (V)", ylabel="I (A)")
-            self.SLDOScanHandler = SLDOCurveHandler(self.instruments, moduleType=self.ModuleType[5:], end_current=site_settings.ModuleCurrentMap[self.master.module_in_use], voltage_limit=site_settings.ModuleVoltageMapSLDO[self.master.module_in_use])
+            self.SLDOScanHandler = SLDOCurveHandler(self.instruments, moduleType=self.ModuleType[5:],
+                                                    end_current=site_settings.ModuleCurrentMap[self.master.module_in_use],
+                                                    voltage_limit=site_settings.ModuleVoltageMapSLDO[self.master.module_in_use])
             self.SLDOScanHandler.makeplotSignal.connect(self.makeSLDOPlot)
             self.SLDOScanHandler.finishedSignal.connect(self.SLDOScanFinished)
             self.SLDOScanHandler.progressSignal.connect(self.updateProgress)
@@ -448,17 +467,21 @@ class TestHandler(QObject):
                 if self.instruments.status()[number]["hv"] == '1':
                     hv_on = True
                     break
+
             if testName == "SCurveScan_2100_FWD":
                 if hv_on:
-                    self.instruments.hv_off()
-                    self.instruments.hv_on(voltage=site_settings.forward_bias_voltage, delay=0.3, step_size=10)
+                    self.instruments.hv_off(step_size=self.step_size, execute_each_step=lambda : self.execute_each_step(False, self.step_size, (getattr(module["hv"], "voltage") for module in self.instruments._module_dict.values()) ))
+                    self.instruments.hv_on(voltage=site_settings.forward_bias_voltage, delay=0.3, step_size=10,
+                                           execute_each_step=lambda:self.ramp_progress_bar(True, 10, site_settings.forward_bias_voltage))
                 else:
-                    self.instruments.hv_on(voltage=site_settings.forward_bias_voltage, delay=0.3, step_size=10)
+                    self.instruments.hv_on(voltage=site_settings.forward_bias_voltage, delay=0.3, step_size=10,
+                                           execute_each_step=lambda:self.ramp_progress_bar(True, 10, site_settings.forward_bias_voltage))
                 testName = "SCurveScan_2100"
                 hv_on = True
             if not hv_on:
                 self.instruments.hv_on(
                     voltage=default_hv_voltage, delay=0.3, step_size=10,
+                    execute_each_step=lambda:self.ramp_progress_bar(True, 10, default_hv_voltage)
                 )
 
         self.tempHistory = [0.0] * self.numChips
@@ -753,7 +776,8 @@ class TestHandler(QObject):
                             self.testIndexTracker, runNumber, module_data
                         )
 
-                        if list(result.values())[0][0]==False: #Need to check that it didnt disconnect
+                        #Checks if the test failed and that test sequence hasn't already been quit
+                        if list(result.values())[0][0]==False and self.halt==False: #Need to check that it didnt disconnect
                             self.errorPopup(list(result.keys())[0])
 
                         results.append(result)
@@ -793,7 +817,7 @@ class TestHandler(QObject):
     #manually edits the .root file in the PH2ACF directory, so there may be a better way to do this
     def copyMostRecentRootFile(self,RunNumber,base_dir,output_dir,test):
         
-        files = root_files[test] if test in root_files.keys() else (test)
+        files = root_files[test] if test in root_files.keys() else [test]
         for name in files:
             # Construct the search pattern for files
             search_pattern = f"{base_dir}/Run{RunNumber}_{name}.root"
@@ -834,12 +858,10 @@ created by felis is empty.")
                 # os.system("cp {0}/test/Results/Run{1}*.xml {2}/".format(os.environ.get("PH2ACF_BASE_DIR"),self.RunNumber,self.output_dir))
 
         except Exception as e:
-            if str(e).startswith("Failed to copy root file to output directory."):
-                print(e)
-                logger.error(str(e))
-                self.forceContinue()
-            else:
-                print("Failed to copy file to output directory")
+            logger.error(e)
+            self.forceContinue()
+            #return True #returns that there was a connection issue
+        #return False #returns that there wasn't a connection issue
 
     #######################################################################
     ##  For real-time terminal display
@@ -859,6 +881,8 @@ created by felis is empty.")
         textline = alltext.split("\n")
         # fileLines = open(self.outputFile,"r")
         # textline = fileLines.readlines()
+
+        print(alltext)
 
         for textStr in textline:
             import re
@@ -1058,18 +1082,23 @@ created by felis is empty.")
         self.outputfile.close()
         # While the process is killed:
 
+        print(2)
         if self.halt == True:
             self.haltSignal.emit(True)
             return
+        print(3)
         if self.run_process.state() == QProcess.Running:
             print("process is still running...  Attempting to terminate before next test.")
             self.run_process.terminate()
             if not self.run_process.waitForFinished(3000):
                 print('process would not terminate, so killing it now...')
                 self.run_process.kill()
+        print(4)
         if "IVCurve" in self.currentTest:
             self.saveTest()
             return
+        
+        print(5)
 
         #Might need this if statment if we do the bumpbond analysis in the GUI.  If done in felis we can remove this.
         #if "PixelAlive_uncoupled" in self.currentTest:
@@ -1087,12 +1116,10 @@ created by felis is empty.")
 
         # Save the output ROOT file to output_dir
         self.saveTest()
+        self.testIndexTracker += 1
 
         # validate the results
-        
         self.validateTest()
-        
-        self.testIndexTracker += 1
 
         # Will send signal to turn off power supply after composite or single tests are run
         if isCompositeTest(self.info):
@@ -1130,9 +1157,11 @@ created by felis is empty.")
         if measurementType=='IVCurve':
             self.IVProgressValue += stepSize/2.0
             self.runwindow.ResultWidget.ProgressBar[self.testIndexTracker].setValue(self.IVProgressValue)
+            self.runwindow.RampProgressBars[self.current_bar].setValue(self.IVProgressValue) #may run into issues if multiple hv's
         if 'SLDO' in measurementType:
             self.SLDOProgressValue += stepSize
             self.runwindow.ResultWidget.ProgressBar[self.testIndexTracker].setValue(self.SLDOProgressValue)
+            self.runwindow.RampProgressBars[self.current_bar].setValue(self.SLDOProgressValue) #may run into issues if multiple hv's
 
     # def updateMeasurement(self, measureType, measure):
     #     """
@@ -1271,11 +1300,13 @@ created by felis is empty.")
         if isCompositeTest(self.info):
             default_hv_voltage = site_settings.icicle_instrument_setup['instrument_dict']['hv']['default_voltage']
             #assumes only 1 HV titled 'hv' in instruments.json
+
             self.master.instruments.hv_on(
                 voltage=default_hv_voltage,
                 delay=0.3,
                 step_size=3,
                 measure=False,
+                execute_each_step=lambda:self.ramp_progress_bar(True, 3, default_hv_voltage)
             )
 
             if self.testIndexTracker == len(CompositeTests[self.info]):
@@ -1331,6 +1362,7 @@ created by felis is empty.")
                 delay=0.3,
                 step_size=5,
                 measure=False,
+                execute_each_step=lambda:self.ramp_progress_bar(True, 5, default_hv_voltage)
             )
 
             if self.testIndexTracker == len(CompositeTests[self.info]):
@@ -1357,34 +1389,97 @@ created by felis is empty.")
 
     def interactiveCheck(self, plot):
         pass
+        
+    def forceContinue(self): #Runs when module disconnection is suspected.
+        # Create the main widget
+        self.force_continue_window = QDialog()
+        self.force_continue_window.setWindowTitle("Failed Component Detected")
 
-    def forceContinue(self):
-        msg_box = QMessageBox()
-        msg_box.setWindowTitle("Failed Component Detected")
-        msg_box.setText("Failed component detected. What would you like to do?")
+        # Create layout
+        self.force_continue_window.layout = QVBoxLayout(self.force_continue_window)
 
         # Add custom buttons
-        exit_button = msg_box.addButton("Exit", QMessageBox.RejectRole)
-        retry_button = msg_box.addButton("Retry", QMessageBox.ActionRole)
-        continue_button = msg_box.addButton("Continue", QMessageBox.AcceptRole)
-        msg_box.setDefaultButton(exit_button)
+        exit_button = QPushButton("Exit")
+        retry_button = QPushButton("Retry")
+        continue_button = QPushButton("Continue")
 
-        # Show the message box and wait for the user's choice
-        msg_box.exec()
+        self.force_continue_window.layout.addWidget(exit_button)
+        self.force_continue_window.layout.addWidget(retry_button)
+        self.force_continue_window.layout.addWidget(continue_button)
 
-        # Check which button was clicked
-        if msg_box.clickedButton() == exit_button:
-            self.run_process.kill()
-            self.halt = True
-            self.haltSignal.emit(self.halt)
-            self.starttime = None
-        elif msg_box.clickedButton() == retry_button:
-            self.outputString.emit(f'Retrying {self.currentTest}...')
-            self.runwindow.ResultWidget.runtime[self.testIndexTracker].setText("") #may need to .update()
-            self.runwindow.ResultWidget.ProgressBar[self.testIndexTracker].setValue(0) #may need to .update(). Automatically adds "0%" text on Progress bar.
-            self.testIndexTracker -= 1
-        elif msg_box.clickedButton() == continue_button:
-            return
+        # Create table for modules with checkboxes
+        self.force_continue_window.table = QTableWidget(len(self.modules), 2)
+        self.force_continue_window.table.setHorizontalHeaderLabels(["Module", "Enabled"])
+
+        for row, module in enumerate(self.modules):
+            # Set the module name in the first column
+            module_name = module.getModuleName()
+            self.force_continue_window.table.setItem(row, 0, QTableWidgetItem(module_name))
+            
+            # Create a QTableWidgetItem for the checkbox in the second column
+            checkbox_item = QTableWidgetItem()
+            checkbox_item.setCheckState(Qt.Checked) if self.statuses[module_name]=="1" else checkbox_item.setCheckState(Qt.Unchecked)
+            self.force_continue_window.table.setItem(row, 1, checkbox_item)
+
+        self.force_continue_window.layout.addWidget(self.force_continue_window.table)
+        self.force_continue_window.setLayout(self.force_continue_window.layout)
+
+        self.force_continue_window.abort = True
+
+        def check_enabledModules():
+            temp_statuses = {}
+            for row in range(self.force_continue_window.table.rowCount()):
+                if self.force_continue_window.table.item(row,1).checkState()==False:
+                    temp_statuses[self.force_continue_window.table.item(row,0).text()]="0"
+                else:
+                    temp_statuses[self.force_continue_window.table.item(row,0).text()]="1"
+            
+            if "1" not in temp_statuses.values():
+                if hasattr(self.force_continue_window, "label")==False:
+                    self.force_continue_window.label = QLabel("At least one module must be enabled.")
+                    self.force_continue_window.label.setStyleSheet('color: red;')
+                    self.force_continue_window.layout.insertWidget(3,self.force_continue_window.label)
+                return False
+            else:
+                self.statuses = temp_statuses
+                self.force_continue_window.abort = False
+                return True
+
+        # Define button handlers
+        def handle_close(event):
+            print(f'self.force_continue_window.abort {self.force_continue_window.abort}')
+            if self.force_continue_window.abort==True:
+                self.run_process.kill()
+                self.halt = True
+                self.haltSignal.emit(self.halt)
+                self.starttime = None
+
+            for row in range(self.force_continue_window.table.rowCount()):
+                if self.force_continue_window.table.item(row,1).checkState()==False:
+                    self.statuses[self.force_continue_window.table.item(row,0).text()]="0"
+
+            event.accept()
+
+        def handle_retry():
+            if check_enabledModules():
+                self.outputString.emit(f'Retrying {self.currentTest}...')
+                self.runwindow.ResultWidget.runtime[self.testIndexTracker].setText("") #may need to .update()
+                self.runwindow.ResultWidget.ProgressBar[self.testIndexTracker].setValue(0) #may need to .update(). Automatically adds "0%" text on Progress bar.
+                self.testIndexTracker -= 1
+                self.force_continue_window.close()
+            
+        def handle_continue():
+            if check_enabledModules(): self.force_continue_window.close()
+
+        # Connect buttons to handlers
+        exit_button.clicked.connect(lambda : self.force_continue_window.close())
+        retry_button.clicked.connect(handle_retry)
+        continue_button.clicked.connect(handle_continue)
+
+        
+        self.force_continue_window.closeEvent = handle_close
+        self.force_continue_window.show()
+        self.force_continue_window.exec_()  # This will block until the window is closed
 
     def upload_to_Panthera(self):
         self.runwindow.UploadButton.setDisabled(True)
@@ -1397,8 +1492,7 @@ created by felis is empty.")
             nummodules = len(self.modules)
 
             for module in self.modules:
-                self.runwindow.ProgressBarLabel.setText("Uploading modules: ["+"##"*int(counter)+"=="*int(nummodules-counter)+"] "+str(counter)+"/"+str(nummodules))
-                QApplication.processEvents() #not ideal. May need to fix later.
+                self.uploadBarSignal.emit(counter, nummodules)
                 status, message = self.felis.upload_results(
                     module.getModuleName(),
                     self.master.username,

--- a/Gui/python/TestHandler.py
+++ b/Gui/python/TestHandler.py
@@ -1,19 +1,15 @@
 from PyQt5 import QtCore
 from PyQt5.QtCore import pyqtSignal, QObject, QProcess
-from PyQt5.QtWidgets import QMessageBox, QTableWidget, QTableWidgetItem
-from PyQt5.QtGui import QFont
+from PyQt5.QtWidgets import QMessageBox, QTableWidget, QTableWidgetItem, QPlainTextEdit
 
-import sys
 import os
 import glob
-import re
 import subprocess
 import threading
 import time
 from datetime import datetime
 import numpy as np
 import matplotlib.pyplot as plt
-import hashlib
 
 from Gui.GUIutils.settings import (
     ModuleLaneMap,
@@ -23,12 +19,9 @@ from Gui.GUIutils.settings import (
 )
 from Gui.GUIutils.guiUtils import (
     ConfigureTest,
-    isActive,
     SetupXMLConfigfromFile,
     SetupRD53Config,
     SetupRD53ConfigfromFile,
-    UpdateXMLValue,
-    CheckXMLValue,
     GenerateXMLConfig,
     isCompositeTest,
     isSingleTest,
@@ -50,7 +43,6 @@ from Gui.QtGUIutils.QtMatplotlibUtils import ScanCanvas
 from Gui.QtGUIutils.QtLoginDialog import *
 #from Gui.python.ResultTreeWidget import *
 from Gui.python.TestValidator import ResultGrader
-from Gui.python.QResultDialog import QResultDialog
 from Gui.python.ANSIColoringParser import parseANSI
 from Gui.python.IVCurveHandler import IVCurveHandler
 from Gui.python.SLDOScanHandler import SLDOCurveHandler
@@ -71,7 +63,7 @@ class TestHandler(QObject):
     haltSignal = pyqtSignal(object)
     finishSignal = pyqtSignal(object)
     proceedSignal = pyqtSignal(object)
-    outputString = pyqtSignal(object)
+    outputString = pyqtSignal(str, QPlainTextEdit)
     stepFinished = pyqtSignal(object)
     historyRefresh = pyqtSignal()
     updateResult = pyqtSignal(object)
@@ -103,7 +95,9 @@ class TestHandler(QObject):
         self.ModuleMap = dict()
         
         self.modules = [module for beboard in self.firmware for module in beboard.getModules()]
-        self.statuses = {module.getModuleName():"1" for module in self.modules}
+        
+        self.finished_tests = []
+        self.BBanalysis_root_files = []
         
         self.numChips = len([chipID for module in self.modules for chipID in module.getEnabledChips().keys()])
                 
@@ -162,21 +156,23 @@ class TestHandler(QObject):
         
         self.figurelist = {}
 
-        self.run_process = QProcess(self)
-        self.run_process.readyReadStandardOutput.connect(
-            self.on_readyReadStandardOutput
-        )
-        self.run_process.finished.connect(self.on_finish)
+        self.run_processes = [QProcess(self) for i in range(len(self.firmware))]
+        for i in range(len(self.run_processes)):
+            self.run_processes[i].readyReadStandardOutput.connect(
+                lambda:self.on_readyReadStandardOutput(i)
+            )
+            self.run_processes[i].finished.connect(lambda:self.on_finish(i))
         self.readingOutput = False
         self.ProgressingMode = "None"
         self.ProgressValue = 0
         self.IVProgressValue = 0
         self.SLDOProgressValue = 0
         self.runtimeList = []
-        self.info_process = QProcess(self)
-        self.info_process.readyReadStandardOutput.connect(
-            self.on_readyReadStandardOutput_info
-        )
+        self.info_processes = [QProcess(self) for i in range(len(self.firmware))]
+        for i in range(len(self.info_processes)):
+            self.info_processes[i].readyReadStandardOutput.connect(
+                lambda:self.on_readyReadStandardOutput_info(i)
+            )
 
         ##---Adding firmware setting-----
         self.fw_process = QProcess(self)
@@ -201,8 +197,6 @@ class TestHandler(QObject):
             )
         )
 
-        self.finished_tests = []
-
         self.initializeRD53Dict()
 
     def initializeRD53Dict(self):
@@ -222,6 +216,18 @@ class TestHandler(QObject):
             fwPath = "{0}_{1}_{2}".format(beboardId, ogId, moduleId)
             self.ModuleMap[fwPath] = moduleName
             print("module map is {0}:{1}".format(fwPath, self.ModuleMap[fwPath]))
+
+    def config_output_dir(self, testName):
+        ModuleIDs = []
+        for module in self.modules:
+            ModuleIDs.append(str(module.getModuleName()))
+        # output_dir gets set to $DATA_dir/Test_{testname}/Test_Module{ModuleID}_{Test}_{TimeStamp}
+        return ConfigureTest(
+            testName,
+            "_Module".join(ModuleIDs),
+            self.output_dir,
+            self.input_dir,
+        )
 
     def configTest(self):
         # Gets the run number by reading from the RunNumber.txt file.
@@ -244,18 +250,7 @@ class TestHandler(QObject):
             testName = self.info
         else:
             testName = self.currentTest
-
-        ModuleIDs = []
-        for module in self.modules:
-            # ModuleIDs.append(str(module.getModuleID()))
-            ModuleIDs.append(str(module.getModuleName()))
-        # output_dir gets set to $DATA_dir/Test_{testname}/Test_Module{ModuleID}_{Test}_{TimeStamp}
-        self.output_dir, self.input_dir = ConfigureTest(
-            testName,
-            "_Module".join(ModuleIDs),
-            self.output_dir,
-            self.input_dir,
-        )
+        self.output_dir, self.input_dir = self.config_output_dir(testName)
 
         # The default place to get the config file is in /settings/RD53Files/CMSIT_RD53.txt
         # FIXME Fix rd53_file[key] so that it reads the correct txt file depending on what module is connected. -> Done!
@@ -284,25 +279,28 @@ class TestHandler(QObject):
                     except:
                         logger.warning("Failed to create " + tmpDir)
                 # Create the xml file from the text file
-                config_file = GenerateXMLConfig(self.firmware, self.currentTest, tmpDir, self.statuses)
+                for firmware in self.firmware:
+                    print('firmware name' + firmware.getBoardName())
+                    config_file = GenerateXMLConfig(firmware, self.currentTest, tmpDir)
 
-                # config_file = os.environ.get('GUI_dir')+ConfigFiles.get(testName, "None")
-                if config_file:
-                    SetupXMLConfigfromFile(
-                        config_file, self.output_dir, self.firmware, self.rd53_file
-                    )
-                else:
-                    logger.warning("No Valid XML configuration file")
-                # QMessageBox.information(None,"Noitce", "Using default XML configuration",QMessageBox.Ok)
+                    if config_file:
+                        SetupXMLConfigfromFile(
+                            config_file, self.output_dir, firmware.getBoardName()
+                        )
+                    else:
+                        logger.warning("No Valid XML configuration file")
+                    # QMessageBox.information(None,"Noitce", "Using default XML configuration",QMessageBox.Ok)
             else:
-                SetupXMLConfigfromFile(
-                    self.config_file, self.output_dir, self.firmware, self.rd53_file
-                )
+                for firmware in self.firmware:
+                    SetupXMLConfigfromFile(
+                        self.config_file, self.output_dir, firmware.getBoardName()
+                    )
         else:
             if self.config_file != "":
-                SetupXMLConfigfromFile(
-                    self.config_file, self.output_dir, self.firmware, self.rd53_file
-                )
+                for firmware in self.firmware:
+                    SetupXMLConfigfromFile(
+                        self.config_file, self.output_dir, firmware.getBoardName()
+                    )
             else:
                 tmpDir = os.environ.get("GUI_dir") + "/Gui/.tmp"
                 if not os.path.isdir(tmpDir) and os.environ.get("GUI_dir"):
@@ -311,19 +309,16 @@ class TestHandler(QObject):
                         logger.info("Creating " + tmpDir)
                     except:
                         logger.warning("Failed to create " + tmpDir)
-                config_file = GenerateXMLConfig(self.firmware, self.currentTest, tmpDir, self.statuses)
-                # config_file = os.environ.get('GUI_dir')+ConfigFiles.get(testName, "None")
-                if config_file:
-                    SetupXMLConfigfromFile(
-                        config_file, self.output_dir, self.firmware, self.rd53_file
-                    )
-                else:
-                    logger.warning("No Valid XML configuration file")
+                # Create the xml file from the text file
+                for firmware in self.firmware:
+                    config_file = GenerateXMLConfig(firmware, self.currentTest, tmpDir)
 
-                # To be remove:
-                # config_file = os.environ.get('GUI_dir')+ConfigFiles.get(testName, "None")
-                # SetupXMLConfigfromFile(config_file,self.output_dir,self.firmwareName,self.rd53_file)
-                # SetupXMLConfig(self.input_dir,self.output_dir)
+                    if config_file:
+                        SetupXMLConfigfromFile(
+                            config_file, self.output_dir, firmware.getBoardName()
+                        )
+                    else:
+                        logger.warning("No Valid XML configuration file")
 
         self.initializeRD53Dict()
         self.config_file = ""
@@ -359,11 +354,6 @@ class TestHandler(QObject):
         self.input_dir = self.output_dir
         self.output_dir = ""
 
-        # self.StatusCanvas.renew()
-        # self.StatusCanvas.update()
-        # self.HistoryLayout.removeWidget(self.StatusCanvas)
-        # self.HistoryLayout.addWidget(self.StatusCanvas)
-
         if isCompositeTest(testName):
             self.runCompositeTest(testName)
         elif isSingleTest(testName):
@@ -375,20 +365,16 @@ class TestHandler(QObject):
     # This loops over all the tests by using the on_finish pyqt decorator defined below
     def runCompositeTest(self, testName):
         if self.halt:
-            # self.LVpowersupply.TurnOff()
             return
         runTestList = CompositeTests[self.info]
 
         if self.testIndexTracker == len(CompositeTests[self.info]):
             self.testIndexTracker = 0
             return
-        # testName = CompositeList[self.info][self.testIndexTracker]
         testName = runTestList[self.testIndexTracker]
-        #if self.info == "AllScan_Tuning":
-        #    updatedGlobalValue[1] = stepWiseGlobalValue[self.testIndexTracker]
         self.runSingleTest(testName)
 
-    def ramp_progress_bar(self, max): #might be a more elegant way to do this
+    def ramp_progress_bar(self, max):
 
         voltages = [getattr(module["hv"], "voltage") for module in self.instruments._module_dict.values()]
 
@@ -400,8 +386,24 @@ class TestHandler(QObject):
             self.updateProgressBar.emit(self.runwindow.RampProgressBars[i], value, text)
 
     def runSingleTest(self, testName):
+
+        if "analyze" in testName.lower(): #This could could maybe be made like 1% more efficient.
+
+            self.output_dir, self.input_dir = self.config_output_dir(testName)
+            self.currentTest = testName
+            self.onFinalTest()
+
+            if self.master.expertMode:
+                self.updateResult.emit(self.output_dir)
+            else:
+                step = "{}:{}".format(self.testIndexTracker, self.currentTest)
+                self.updateResult.emit((step, self.figurelist))
+            self.runwindow.ResultWidget.ProgressBar[self.testIndexTracker].setValue(100)
+            return
+
         print("Executing Single Step test...")
-        self.outputString.emit("Executing Single Step test...")
+        for console in self.runwindow.ConsoleViews:
+            self.outputString.emit("Executing Single Step test...", console)
 
         if self.instruments:
             lv_on = False
@@ -414,15 +416,6 @@ class TestHandler(QObject):
                     voltage=site_settings.ModuleVoltageMapSLDO[self.master.module_in_use],
                     current=site_settings.ModuleCurrentMap[self.master.module_in_use],
                 )
-        #if testName == "Analyze_Bumpbonds":
-        #    self.currentTest = testName
-        #    self.configTest()
-        #    self.outputString.emit("Beginning Bumpbond Analysis")
-        #    self.analyze_bumpbonds()
-        #    self.outputString.emit("Bumpbond Analysis Complete")
-        #    self.on_finish()
-        #    return
-
 
         if testName == "IVCurve":
             self.currentTest = testName
@@ -433,7 +426,7 @@ class TestHandler(QObject):
             self.IVCurveHandler.finished.connect(self.IVCurveFinished)
             self.IVCurveHandler.progressSignal.connect(self.updateProgress)
             self.IVCurveHandler.startSignal.connect(self.setupQProcess)
-            self.outputString.emit("Beginning IVCurve")
+            for console in self.consoles: self.outputString.emit("Beginning IVCurve", console)
             self.IVCurveHandler.IVCurve()
             return
 
@@ -443,7 +436,6 @@ class TestHandler(QObject):
             self.SLDOScanData = []
             self.SLDOfilelist = []
             self.SLDOProgressValue = 0
-            #self.SLDOScanResult = ScanCanvas(self, xlabel="Voltage (V)", ylabel="I (A)")
             self.SLDOScanHandler = SLDOCurveHandler(self.instruments, moduleType=self.ModuleType[5:],
                                                     end_current=site_settings.ModuleCurrentMap[self.master.module_in_use],
                                                     voltage_limit=site_settings.ModuleVoltageMapSLDO[self.master.module_in_use],
@@ -452,7 +444,7 @@ class TestHandler(QObject):
             self.SLDOScanHandler.finishedSignal.connect(self.SLDOScanFinished)
             self.SLDOScanHandler.progressSignal.connect(self.updateProgress)
             self.SLDOScanHandler.abortSignal.connect(self.urgentStop)
-            self.outputString.emit("Beginning SLDOScan")
+            for console in self.consoles: self.outputString.emit("Beginning SLDOScan", console)
             self.SLDOScanHandler.SLDOScan()
             return
 
@@ -489,6 +481,7 @@ class TestHandler(QObject):
         self.starttime = None
         self.ProgressingMode = "None"
         self.currentTest = testName
+
         self.updateOptimizedXMLValues()
         self.configTest()
 
@@ -508,120 +501,8 @@ class TestHandler(QObject):
             self.outputfile = open(self.outputFile, "a")
         else:
             self.outputfile = open(self.outputFile, "w")
-        # self.ContinueButton.setDisabled(True)
-        # self.run_process.setProgram()
         self.setupQProcess()
 
-        """
-        self.info_process.setProcessChannelMode(QtCore.QProcess.MergedChannels)
-        self.info_process.setWorkingDirectory(
-            os.environ.get("PH2ACF_BASE_DIR") + "/test/"
-        )
-        if self.currentTest == "CommunicationTest":
-            self.info_process.start(
-                "echo",
-                [
-                    "Running COMMAND: CMSITminiDAQ  -f  CMSIT.xml  -p"
-                ],
-            )
-        else:
-            self.info_process.start(
-                "echo",
-                [
-                    "Running COMMAND: CMSITminiDAQ  -f  CMSIT.xml  -c  {}".format(
-                        Test_to_Ph2ACF_Map[self.currentTest]
-                    )
-                ],
-            )
-        self.info_process.waitForFinished()
-
-        self.run_process.setProcessChannelMode(QtCore.QProcess.MergedChannels)
-        self.run_process.setWorkingDirectory(
-            os.environ.get("PH2ACF_BASE_DIR") + "/test/"
-        )
-        # self.run_process.setStandardOutputFile(self.outputFile)
-        # self.run_process.setStandardErrorFile(self.errorFile)
-
-        self.fw_process.setProcessChannelMode(QtCore.QProcess.MergedChannels)
-        self.fw_process.setWorkingDirectory(
-            os.environ.get("PH2ACF_BASE_DIR") + "/test/"
-        )
-        """
-        #self.FWisPresent = True
-        """
-		if not self.FWisPresent:
-			print("checking if firmware is on the SD card")
-			fwlist = subprocess.run(["fpgaconfig","-c",os.environ.get('PH2ACF_BASE_DIR')+'/test/CMSIT.xml',"-l"],stdout=subprocess.PIPE,stderr=subprocess.PIPE)
-			print("firmwarelist is {0}".format(fwlist.stdout.decode('UTF-8')))
-			print("firmwareImage is {0}".format(self.firmwareImage))
-			if self.firmwareImage in fwlist.stdout.decode('UTF-8'):
-				self.FWisPresent = True
-				print("firmware is on SD card")
-			else:
-				try:
-					fwsave = subprocess.run(["fpgaconfig","-c","CMSIT.xml","-f","{}".format(os.environ.get("GUI_dir")+'/FirmwareImages/' + firmwareImage),"i","{}".format(firmwareImage)],stdout=subprocess.PIPE,stderr=subprocess.PIPE)
-					#self.fw_process.start("fpgaconfig",["-c","CMSIT.xml","-f","{}".format(os.environ.get("GUI_dir")+'/FirmwareImages/' + self.firmwareImage),"-i","{}".format(self.firmwareImage)])
-					print(fwsave.stdout.decode('UTF-8'))
-					self.FWisPresent = True
-				except:
-					print("unable to save {0} to FC7 SD card".format(os.environ.get("GUI_dir")+'/FirmwareImages/' + firmwareImage))
-
-		self.FWisLoaded = True
-		if not self.FWisLoaded:
-			self.fw_process.start("fpgaconfig",["-c","CMSIT.xml","-i", "{}".format(self.firmwareImage)])
-			self.fw_process.waitForFinished()
-			self.fw_process.start("CMSITminiDAQ",["-f","CMSIT.xml","-r"])
-			self.fw_process.waitForFinished()
-			self.FWisLoaded = True
-			print('Firmware image is now loaded')
-		"""
-
-        #if self.isTDACtuned:
-        #    UpdateXMLValue(
-        #        "{0}/test/CMSIT.xml".format(os.environ.get("PH2ACF_BASE_DIR")),
-        #        "DoNSteps",
-        #        "2",
-        #    )
-
-        #CheckXMLValue(
-        #    "{0}/test/CMSIT.xml".format(os.environ.get("PH2ACF_BASE_DIR")), "DoNSteps"
-        #)
-        """
-        if self.currentTest == "CommunicationTest":
-            self.run_process.start(
-                "CMSITminiDAQ",
-                ["-f", "CMSIT.xml", "-p"],
-            )
-        else:
-            self.run_process.start(
-                "CMSITminiDAQ",
-                ["-f", "CMSIT.xml", "-c", "{}".format(Test_to_Ph2ACF_Map[self.currentTest])],
-            )
-
-        #self.run_process.start(
-        #    "CMSITminiDAQ",
-        #    ["-f", "CMSIT.xml", "-c", "{}".format(Test_to_Ph2ACF_Map[self.currentTest])],
-        #)
-        if Test_to_Ph2ACF_Map[self.currentTest] == "threqu":
-            self.isTDACtuned = True
-
-        # Question = QMessageBox()
-        # Question.setIcon(QMessageBox.Question)
-        # Question.setrunWindowTitle('SingleTest Finished')
-        # Question.setText('Save current result and proceed?')
-        # Question.setStandardButtons(QMessageBox.No| QMessageBox.Save | QMessageBox.Yes)
-        # Question.setDefaultButton(QMessageBox.Yes)
-        # customizedButton = Question.button(QMessageBox.Save)
-        # customizedButton.setText('Save Only')
-        # reply  = Question.exec_()
-
-        # if reply == QMessageBox.Yes or reply == QMessageBox.Save:
-        # 	self.saveTest()
-        # if reply == QMessageBox.No or reply == QMessageBox.Save:
-        # 	self.haltSignal = True
-        # self.refreshHistory()
-        # self.finishSingal = False
-        """
     def setupQProcess(self):
         self.tempHistory = [0.0] * self.numChips
         self.tempindex = 0
@@ -631,34 +512,39 @@ class TestHandler(QObject):
             self.outputfile = open(self.outputFile, "a")
         else:
             self.outputfile = open(self.outputFile, "w")
-        self.info_process.setProcessChannelMode(QtCore.QProcess.MergedChannels)
-        self.info_process.setWorkingDirectory(
-            os.environ.get("PH2ACF_BASE_DIR") + "/test/"
-        )
-        if self.currentTest == "CommunicationTest":
-            self.info_process.start(
-                "echo",
-                [
-                    "Running COMMAND: CMSITminiDAQ  -f  CMSIT.xml  -p"
-                ],
+        
+        for process in self.info_processes:
+            process.setProcessChannelMode(QtCore.QProcess.MergedChannels)
+            process.setWorkingDirectory(
+                os.environ.get("PH2ACF_BASE_DIR") + "/test/"
             )
-        else:
-            self.info_process.start(
-                "echo",
-                [
-                    "Running COMMAND: CMSITminiDAQ  -f  CMSIT.xml  -c  {}".format(
-                        Test_to_Ph2ACF_Map[self.currentTest]
-                    )
-                ],
-            )
-        self.info_process.waitForFinished()
 
-        self.run_process.setProcessChannelMode(QtCore.QProcess.MergedChannels)
-        self.run_process.setWorkingDirectory(
-            os.environ.get("PH2ACF_BASE_DIR") + "/test/"
-        )
-        # self.run_process.setStandardOutputFile(self.outputFile)
-        # self.run_process.setStandardErrorFile(self.errorFile)
+        if self.currentTest == "CommunicationTest":
+            for i in range(len(self.firmware)):
+                self.info_processes[i].start(
+                    "echo",
+                    [
+                        f"Running COMMAND: CMSITminiDAQ  -f  CMSIT_{self.firmware[i].getBoardName()}.xml  -p"
+                    ],
+                )
+        else:
+            for i in range(len(self.firmware)):
+                self.info_processes[i].start(
+                    "echo",
+                    [
+                        "Running COMMAND: CMSITminiDAQ  -f  CMSIT_{0}.xml  -c  {1}".format(
+                            self.firmware[i].getBoardName(), Test_to_Ph2ACF_Map[self.currentTest]
+                        )
+                    ],
+                )
+                    
+        for process in self.info_processes: process.waitForFinished()
+
+        for process in self.run_processes:
+            process.setProcessChannelMode(QtCore.QProcess.MergedChannels)
+            process.setWorkingDirectory(
+                os.environ.get("PH2ACF_BASE_DIR") + "/test/"
+            )
 
         self.fw_process.setProcessChannelMode(QtCore.QProcess.MergedChannels)
         self.fw_process.setWorkingDirectory(
@@ -666,33 +552,35 @@ class TestHandler(QObject):
         )
         
         if self.currentTest == "CommunicationTest":
-            self.run_process.start(
-                "CMSITminiDAQ",
-                ["-f", "CMSIT.xml", "-p"],
-            )
+            for i in range(len(self.firmware)):
+                self.run_processes[i].start(
+                    "CMSITminiDAQ",
+                    ["-f", f"CMSIT_{self.firmware[i].getBoardName()}.xml", "-p"],
+                )
         else:
-            self.run_process.start(
-                "CMSITminiDAQ",
-                ["-f", "CMSIT.xml", "-c", "{}".format(Test_to_Ph2ACF_Map[self.currentTest])],
-            )
+            for i in range(len(self.firmware)):
+                self.run_processes[i].start(
+                    "CMSITminiDAQ",
+                    ["-f", f"CMSIT_{self.firmware[i].getBoardName()}.xml", "-c", "{}".format(Test_to_Ph2ACF_Map[self.currentTest])],
+                )
 
 
     def abortTest(self):
         self.halt = True
-        self.run_process.kill()
+        for process in self.run_processes: process.kill()
 
         self.haltSignal.emit(self.halt)
 
         self.starttime = None
         if self.IVCurveHandler:
-            self.outputString.emit("Aborting IVCurve")
+            for console in self.consoles: self.outputString.emit("Aborting IVCurve", console)
             self.IVCurveHandler.stop()
         if self.SLDOScanHandler:
-            self.outputString.emit("Aborting SLDOScan")
+            for console in self.consoles: self.outputString.emit("Aborting SLDOScan", console)
             self.SLDOScanHandler.stop()
 
     def urgentStop(self):
-        self.run_process.kill()
+        for process in self.run_processes: process.kill()
         self.halt = True
         self.haltSignal.emit(self.halt)
         self.starttime = None
@@ -716,9 +604,9 @@ class TestHandler(QObject):
                             'hybridID':hybridID,
                             'module':module
                         }
-                        result = ResultGrader(
+                        result, self.BBanalysis_root_files = ResultGrader(
                             self.felis, self.output_dir, self.currentTest,
-                            self.testIndexTracker, runNumber, module_data
+                            self.testIndexTracker, runNumber, module_data, self.BBanalysis_root_files
                         )
 
                         results.append(result)
@@ -739,7 +627,7 @@ class TestHandler(QObject):
             directory = os.path.join(scratch, test)
             
             for filename in os.listdir(directory):
-                if filename.lower().endswith('.svg'):
+                if filename.lower().endswith('.svg') or filename.lower().endswith('.png'):
                     plot_paths.append(os.path.join(directory, filename))
             
             return plot_paths
@@ -758,17 +646,19 @@ class TestHandler(QObject):
     #manually edits the .root file in the PH2ACF directory, so there may be a better way to do this
     def copyMostRecentRootFile(self,RunNumber,base_dir,output_dir,test):
         
-        files = root_files[test] if test in root_files.keys() else [test]
+        files = root_files[test] if test in root_files.keys() else (test,)
         for name in files:
             # Construct the search pattern for files
             search_pattern = f"{base_dir}/Run{RunNumber}_{name}.root"
+            logger.debug(f"Looking for {search_pattern}")
+            print(f"Looking for {search_pattern}")
 
             # Find all matching files
             matching_files = glob.glob(search_pattern)
 
             if len(matching_files)==0:
                 raise Exception(f"Failed to copy root file to output directory. \
-Module disconnection detected because felis didn't \
+Module disconnection detected because Ph2_ACF didn't \
 create {search_pattern}.")
 
             # Sort files by modification time (newest first)
@@ -777,45 +667,38 @@ create {search_pattern}.")
             if os.path.getsize(latest_file)==0:
                 raise Exception(f"Failed to copy root file to output directory. \
 Module disconnection detected because {latest_file} \
-created by felis is empty.")
+created by Ph2_ACF is empty.")
 
             # Copy the most recent file to the output directory
             os.system(f"cp {latest_file} {output_dir}/")
 
-    def saveTest(self):
-        # if self.parent.current_test_grade < 0:
-        if self.run_process.state() == QProcess.Running:
+    def saveTest(self, processIndex:int):
+        if self.run_processes[processIndex].state() == QProcess.Running:
             QMessageBox.critical(self, "Error", "Process not finished", QMessageBox.Ok)
             return
 
         try:
             if self.RunNumber == "-1":
                 self.copyMostRecentRootFile('000000',os.environ.get("PH2ACF_BASE_DIR")+"/test/Results",self.output_dir,self.currentTest)
-                # os.system("cp {0}/test/Results/Run000000*.txt {1}/".format(os.environ.get("PH2ACF_BASE_DIR"),self.output_dir))
-                # os.system("cp {0}/test/Results/Run000000*.xml {1}/".format(os.environ.get("PH2ACF_BASE_DIR"),self.output_dir))
             else:
                 self.copyMostRecentRootFile(self.RunNumber,os.environ.get("PH2ACF_BASE_DIR")+"/test/Results",self.output_dir,self.currentTest)
-                # os.system("cp {0}/test/Results/Run{1}*.txt {2}/".format(os.environ.get("PH2ACF_BASE_DIR"),self.RunNumber,self.output_dir))
-                # os.system("cp {0}/test/Results/Run{1}*.xml {2}/".format(os.environ.get("PH2ACF_BASE_DIR"),self.RunNumber,self.output_dir))
 
         except Exception as e:
             logger.error(e)
-            self.forceContinue()
-            #return True #returns that there was a connection issue
-        #return False #returns that there wasn't a connection issue
+            self.forceContinue(self.firmware[processIndex])
 
     #######################################################################
     ##  For real-time terminal display
     #######################################################################
 
     @QtCore.pyqtSlot()
-    def on_readyReadStandardOutput(self):
+    def on_readyReadStandardOutput(self, processIndex:int):
         if self.readingOutput == True:
             print("Thread competition detected")
             return
         self.readingOutput = True
 
-        alltext = self.run_process.readAllStandardOutput().data().decode()
+        alltext = self.run_processes[processIndex].readAllStandardOutput().data().decode()
         self.outputfile.write(alltext)
     #print(alltext)
         # outputfile.close()
@@ -931,8 +814,8 @@ created by felis is empty.")
                     except Exception as e:
                         print("Failed due to {0}".format(e))
                 text = textStr.encode("ascii")
-                numUpAnchor, text = parseANSI(text)
-                self.outputString.emit(text.decode("utf-8"))
+                _, text = parseANSI(text)
+                self.outputString.emit(text.decode("utf-8"), self.runwindow.ConsoleViews[processIndex])
                 continue
             #This next block needs to be edited once Ph2ACF bug is fixed.  Remove the Fixme when ready.
             
@@ -946,12 +829,12 @@ created by felis is empty.")
                 self.outputString.emit(
                     '<b><span style="color:#ff0000;"> Performing the {} test </span></b>'.format(
                         self.currentTest
-                    )
+                    ),self.runwindow.ConsoleViews[processIndex]
                 )
 
             text = textStr.encode("ascii")
-            numUpAnchor, text = parseANSI(text)
-            self.outputString.emit(text.decode("utf-8"))
+            _, text = parseANSI(text)
+            self.outputString.emit(text.decode("utf-8"),self.runwindow.ConsoleViews[processIndex])
 
         self.readingOutput = False
 
@@ -1001,23 +884,22 @@ created by felis is empty.")
 
     # Reads data that is normally printed to the terminal and saves it to the output file
     @QtCore.pyqtSlot()
-    def on_readyReadStandardOutput_info(self):
+    def on_readyReadStandardOutput_info(self, processIndex:int):
         if os.path.exists(self.outputFile):
             outputfile = open(self.outputFile, "a")
         else:
             outputfile = open(self.outputFile, "w")
 
-        alltext = self.info_process.readAllStandardOutput().data().decode()
+        alltext = self.info_processes[processIndex].readAllStandardOutput().data().decode()
         outputfile.write(alltext)
         outputfile.close()
         textline = alltext.split("\n")
 
         for textStr in textline:
-            self.outputString.emit(textStr)
-            # self.ConsoleView.appendHtml(textStr)
+            self.outputString.emit(textStr,self.runwindow.ConsoleViews[processIndex])
 
     @QtCore.pyqtSlot()
-    def on_finish(self):
+    def on_finish(self, processIndex:int):
         self.outputfile.close()
         # While the process is killed:
 
@@ -1025,53 +907,27 @@ created by felis is empty.")
             self.haltSignal.emit(True)
             return
 
-        if self.run_process.state() == QProcess.Running:
+        if self.run_processes[processIndex].state() == QProcess.Running:
             print("process is still running...  Attempting to terminate before next test.")
-            self.run_process.terminate()
-            if not self.run_process.waitForFinished(3000):
+            self.run_processes[processIndex].terminate()
+            if not self.run_processes[processIndex].waitForFinished(3000):
                 print('process would not terminate, so killing it now...')
-                self.run_process.kill()
+                self.run_processes[processIndex].kill()
 
         if "IVCurve" in self.currentTest:
-            self.saveTest()
+            self.saveTest(processIndex)
             return
-        
-        #Might need this if statment if we do the bumpbond analysis in the GUI.  If done in felis we can remove this.
-        #if "PixelAlive_uncoupled" in self.currentTest:
-        #    self.bumpbond_analysis()
-
-        # To be removed
-        # if isCompositeTest(self.info):
-        # 	self.ListWidget.insertItem(self.listWidgetIndex, "{}_Module_0_Chip_0".format(CompositeList[self.info][self.testIndexTracker-1]))
-        # if isSingleTest(self.info):
-        # 	self.ListWidget.insertItem(self.listWidgetIndex, "{}_Module_0_Chip_0".format(self.info))
 
         self.saveConfigs()
 
-        EnableReRun = False
-
         # Save the output ROOT file to output_dir
-        self.saveTest()
+        self.saveTest(processIndex)
         self.testIndexTracker += 1
 
         # validate the results
         self.validateTest()
 
-        # Will send signal to turn off power supply after composite or single tests are run
-        if isCompositeTest(self.info):
-            if self.testIndexTracker == len(CompositeTests[self.info]): # Checks that this was the last test in the sequence.
-                self.powerSignal.emit()
-                EnableReRun = True
-                if self.autoSave:
-                    self.runwindow.upload_to_Panthera_starter()
-                if self.info == "FWD-RVS Bias" or self.info == "CrossTalk":
-                    self.bumpbond_analysis()
-        
-        elif isSingleTest(self.info):
-            EnableReRun = True
-            self.powerSignal.emit()
-            if self.autoSave:
-                self.runwindow.upload_to_Panthera_starter()
+        EnableReRun = self.onFinalTest()
 
         self.stepFinished.emit(EnableReRun)
 
@@ -1079,7 +935,6 @@ created by felis is empty.")
         self.historyRefresh.emit()
         if self.master.expertMode:
             self.updateResult.emit(self.output_dir)
-            #print(self.output_dir)
         else:
             step = "{}:{}".format(self.testIndexTracker, self.currentTest)
             self.updateResult.emit((step, self.figurelist))
@@ -1089,6 +944,49 @@ created by felis is empty.")
         if isCompositeTest(self.info):
             self.runTest()
 
+    def onFinalTest(self):
+        EnableReRun = False
+        # Will send signal to turn off power supply after composite or single tests are run
+        if isCompositeTest(self.info):
+            if self.testIndexTracker == len(CompositeTests[self.info]): # Checks that this was the last test in the sequence.
+                self.powerSignal.emit()
+                EnableReRun = True
+                if self.autoSave:
+                    self.runwindow.upload_to_Panthera_starter()
+                if self.info == "FWD-RVS Bias" or self.info == "CrossTalk":
+                    self.bumpbond_analysis()
+
+                if len(self.BBanalysis_root_files)>0:
+                    for beboard in self.firmware:
+                        boardID = beboard.getBoardID()
+                        for OG in beboard.getAllOpticalGroups().values():
+                            ogID = OG.getOpticalGroupID()
+                            for module in OG.getAllModules().values():
+                                hybridID = module.getFMCPort()
+                                module_data = {
+                                    'boardID':boardID,
+                                    'ogID':ogID,
+                                    'hybridID':hybridID,
+                                    'module':module
+                                }
+
+                                "This works"
+                                self.felis.set_result(
+                                    self.BBanalysis_root_files,
+                                    module_data['module'].getModuleName(),
+                                    f"{self.testIndexTracker:02d}_{self.currentTest}",
+                                    Test_to_Ph2ACF_Map[self.currentTest],
+                                )
+                                self.figurelist[module.getModuleName()] = self.collect_plots(module.getModuleName())
+        
+        elif isSingleTest(self.info):
+            EnableReRun = True
+            self.powerSignal.emit()
+            if self.autoSave:
+                self.runwindow.upload_to_Panthera_starter()
+
+        return EnableReRun
+
     def updateProgress(self, measurementType, stepSize):
         if measurementType=='IVCurve':
             self.IVProgressValue += stepSize/2.0
@@ -1097,61 +995,6 @@ created by felis is empty.")
         if 'SLDO' in measurementType:
             self.SLDOProgressValue += stepSize
             self.runwindow.ResultWidget.ProgressBar[self.testIndexTracker].setValue(self.SLDOProgressValue)
-
-    # def updateMeasurement(self, measureType, measure):
-    #     """
-    #     Plot data continuosly, update progress bar, save resulting plot as svg to tmp dir
-    #     if in simplified gui add to figure list
-    #     """
-    #     if measureType == "IVCurve":
-    #         voltages = measure["voltage"]
-    #         currents = measure["current"]
-    #         logger.debug(f"Voltages: {voltages}")
-    #         logger.debug(f"Currents: {currents}")
-    #         # self.runwindow.ResultWidget.ProgressBar[self.testIndexTracker].setValue(
-    #         #     Percentage * 100
-    #         # )
-    #         tmpDir = os.environ.get("GUI_dir") + "/Gui/.tmp"
-    #         if not os.path.isdir(tmpDir) and os.environ.get("GUI_dir"):
-    #             try:
-    #                 os.mkdir(tmpDir)
-    #                 logger.info("Creating " + tmpDir)
-    #             except:
-    #                 logger.warning("Failed to create " + tmpDir)
-    #         svgFile = "IVCurve.svg"
-    #         output = self.IVCurveResult.saveToSVG(tmpDir + "/" + svgFile)
-    #         print(f"SVG file output: {output}")
-    #         self.IVCurveResult.update()
-    #         if not self.master.expertMode:
-    #             step = "IVCurve"
-    #             self.figurelist = {"-1": [output]}
-    #             self.updateIVResult.emit((step, self.figurelist))
-
-    #     if measureType == "SLDOScan":
-    #         voltages = measure["voltage"]
-    #         currents = measure["current"]
-    #         Percentage = measure["percentage"]
-    #         self.runwindow.ResultWidget.ProgressBar[self.testIndexTracker].setValue(
-    #             Percentage * 100
-    #         )
-    #         if float(voltages) < -0.1 and float(currents) < -0.1:
-    #             return
-    #         self.SLDOScanData.append([voltages, currents])
-    #         self.SLDOScanResult.updatePlots(self.SLDOScanData)
-    #         tmpDir = os.environ.get("GUI_dir") + "/Gui/.tmp"
-    #         if not os.path.isdir(tmpDir) and os.environ.get("GUI_dir"):
-    #             try:
-    #                 os.mkdir(tmpDir)
-    #                 logger.info("Creating " + tmpDir)
-    #             except:
-    #                 logger.warning("Failed to create " + tmpDir)
-    #         svgFile = "SLDOScan.svg"
-    #         output = self.SLDOScanResult.saveToSVG(tmpDir + "/" + svgFile)
-    #         self.SLDOScanResult.update()
-    #         if not self.master.expertMode:
-    #             step = "SLDOScan"
-    #             self.figurelist = {"-1": [output]}
-    #             self.updateResult.emit((step, self.figurelist))
 
     def makeSLDOPlot(self, total_result: np.ndarray, pin: str):
         for module in self.modules:
@@ -1181,17 +1024,13 @@ created by felis is empty.")
     def IVCurveFinished(self, test: str, measure: dict):
         # Get the current timestamp
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        self.run_process.write(b"\n")
-        self.run_process.waitForBytesWritten()
-        self.run_process.waitForFinished()
+        for process in self.run_processes:
+            process.write(b"\n")
+            process.waitForBytesWritten()
+            process.waitForFinished()
         self.outputString.emit(f"Voltages: {measure['voltage']}")
         self.outputString.emit(f"Currents: {measure['current']}")
 
-                        
-#        for module in self.modules: #Only one HV and IVCurve works by sweeping HV. Ask about this.
-#            moduleName = module.getModuleName()
-#        self.run_process.terminate()
-#        self.run_process.waitForFinished()
         for module in self.modules:
             ogId = module.getOpticalGroup().getOpticalGroupID()
             beboardId = module.getOpticalGroup().getBeBoard().getBoardID()
@@ -1325,10 +1164,14 @@ created by felis is empty.")
     def interactiveCheck(self, plot):
         pass
         
-    def forceContinue(self): #Runs when module disconnection is suspected.
+    def forceContinue(self, board): #board:QtBeBoard. Runs when module disconnection is suspected.
+        
+        fc7modules = board.getModules()
+
         # Create the main widget
         self.force_continue_window = QDialog()
-        self.force_continue_window.setWindowTitle("Failed Component Detected")
+        self.force_continue_window.setMaximumWidth(375)
+        self.force_continue_window.setWindowTitle(f"{board.getBoardName()}: Failed Component Detected")
 
         # Create layout
         self.force_continue_window.layout = QVBoxLayout(self.force_continue_window)
@@ -1343,17 +1186,17 @@ created by felis is empty.")
         self.force_continue_window.layout.addWidget(continue_button)
 
         # Create table for modules with checkboxes
-        self.force_continue_window.table = QTableWidget(len(self.modules), 2)
+        self.force_continue_window.table = QTableWidget(len(fc7modules), 2)
         self.force_continue_window.table.setHorizontalHeaderLabels(["Module", "Enabled"])
-
-        for row, module in enumerate(self.modules):
+        
+        for row, module in enumerate(fc7modules):
             # Set the module name in the first column
             module_name = module.getModuleName()
             self.force_continue_window.table.setItem(row, 0, QTableWidgetItem(module_name))
             
             # Create a QTableWidgetItem for the checkbox in the second column
             checkbox_item = QTableWidgetItem()
-            checkbox_item.setCheckState(Qt.Checked) if self.statuses[module_name]=="1" else checkbox_item.setCheckState(Qt.Unchecked)
+            checkbox_item.setCheckState(Qt.Checked) if module.getEnabled()=="1" else checkbox_item.setCheckState(Qt.Unchecked)
             self.force_continue_window.table.setItem(row, 1, checkbox_item)
 
         self.force_continue_window.layout.addWidget(self.force_continue_window.table)
@@ -1361,29 +1204,29 @@ created by felis is empty.")
 
         self.force_continue_window.abort = True
 
-        def check_enabledModules():
-            temp_statuses = {}
-            for row in range(self.force_continue_window.table.rowCount()):
-                if self.force_continue_window.table.item(row,1).checkState()==False:
-                    temp_statuses[self.force_continue_window.table.item(row,0).text()]="0"
-                else:
-                    temp_statuses[self.force_continue_window.table.item(row,0).text()]="1"
-            
-            if "1" not in temp_statuses.values():
-                if hasattr(self.force_continue_window, "label")==False:
-                    self.force_continue_window.label = QLabel("At least one module must be enabled.")
-                    self.force_continue_window.label.setStyleSheet('color: red;')
-                    self.force_continue_window.layout.insertWidget(3,self.force_continue_window.label)
-                return False
-            else:
-                self.statuses = temp_statuses
-                self.force_continue_window.abort = False
-                return True
+        def check_enabledModules(): #Not sure if this is maximally efficient
+            for row in range(len(fc7modules)):
+                if self.force_continue_window.table.item(row,1).checkState()==Qt.Checked:
+                    
+                    for row in range(len(fc7modules)):
+                        if self.force_continue_window.table.item(row,1).checkState()==Qt.Checked:
+                            fc7modules[row].setEnabled("1")
+                        else:
+                            fc7modules[row].setEnabled("0")
+
+                    self.force_continue_window.abort = False
+                    return True
+                
+            if hasattr(self.force_continue_window, "label")==False:
+                self.force_continue_window.label = QLabel("At least one module must be enabled.")
+                self.force_continue_window.label.setStyleSheet('color: red;')
+                self.force_continue_window.layout.insertWidget(3,self.force_continue_window.label)
+            return False
 
         # Define button handlers
         def handle_close(event):
             if self.force_continue_window.abort==True:
-                self.run_process.kill()
+                for process in self.run_processes: process.kill()
                 self.halt = True
                 self.haltSignal.emit(self.halt)
                 self.starttime = None

--- a/Gui/python/TestHandler.py
+++ b/Gui/python/TestHandler.py
@@ -1,6 +1,7 @@
 from PyQt5 import QtCore
 from PyQt5.QtCore import pyqtSignal, QObject, QProcess
-from PyQt5.QtWidgets import QMessageBox
+from PyQt5.QtWidgets import QMessageBox, QTableWidget, QTableWidgetItem
+from PyQt5.QtGui import QFont
 
 import sys
 import os
@@ -33,6 +34,7 @@ from Gui.GUIutils.guiUtils import (
     isSingleTest,
     formatter,
 )
+
 from Gui.python.ROOTInterface import executeCommandSequence
 from felis.felis import Felis
 from InnerTrackerTests.Analysis.IVCurve_CSV_to_ROOT import IVCurve_CSV_to_ROOT
@@ -673,7 +675,61 @@ class TestHandler(QObject):
         self.haltSignal.emit(self.halt)
         self.starttime = None
 
-    def validateTest(self):
+    def getExplanation(self,rowNum):
+        n=0
+        moduleName = self.failtable.item(rowNum,0).text()
+        for test_results in self.runwindow.modulestatus:
+            for module_result in test_results:
+                if module_result[moduleName][0]==False:
+                    n+=1
+                    if n==rowNum:
+                        return module_result[moduleName][1]
+        return "Could not retrieve additional information."
+
+    def errorPopup(self, module_name):
+        if hasattr(self, "fail_window")==False:
+            self.fail_window = QWidget()  # Create a regular window instead of QDialog
+            self.fail_window.setWindowTitle("Failed Tests")
+            self.fail_window.setGeometry(150, 150, 400, 250)
+
+            self.failtable = QTableWidget(1, 2)  # Ensure at least 1 row
+            self.failtable.itemClicked.connect(lambda : QMessageBox.information(
+                None, "Additional Information", self.getExplanation(item.row())
+                , QMessageBox.Ok))
+            #Should instead connect itemClicked to runwindow.displayTestResultPopup
+
+            self.failtable.setShowGrid(False)
+
+            # Set bold font for headers
+            bold_font = QFont()
+            bold_font.setBold(True)
+
+            headers = ["Module", "Test"]
+            for col, text in enumerate(headers):
+                item = QTableWidgetItem(text)
+                item.setFont(bold_font)
+                self.failtable.setItem(0, col, item)
+
+            button = QPushButton("OK", self.fail_window)
+            button.clicked.connect(self.fail_window.close)  # Close window when clicked
+
+            layout = QVBoxLayout()
+            layout.addWidget(self.failtable)
+            layout.addWidget(button)
+            self.fail_window.setLayout(layout)
+
+            self.fail_window.show()
+        
+        row_num=self.failtable.rowCount()
+        self.failtable.insertRow(row_num)
+        self.failtable.setItem(row_num,0,QTableWidgetItem(module_name))
+        self.failtable.setItem(row_num,1,QTableWidgetItem(self.currentTest))
+        item = self.failtable.item(row_num,0)
+        self.failtable.resizeColumnsToContents()
+        self.fail_window.resize(
+            sum((self.failtable.columnWidth(i) for i in range(self.failtable.columnCount())))+50,self.fail_window.height())
+
+    def validateTest(self, connectionFail): #ATOC = At time of commit
         self.finished_tests.append(self.currentTest)
         try:
             passed = []
@@ -696,14 +752,17 @@ class TestHandler(QObject):
                             self.felis, self.output_dir, self.currentTest,
                             self.testIndexTracker, runNumber, module_data
                         )
+
+                        if list(result.values())[0][0]==False and connectionFail==False:
+                            self.errorPopup(list(result.keys())[0])
+
                         results.append(result)
                         passed.append(list(result.values())[0][0])
                                                 
                         self.figurelist[module.getModuleName()] = self.collect_plots(module.getModuleName())
             
             self.updateValidation.emit(results)
-            self.updateFinishedTests.emit(self.finished_tests)
-            return all(passed)
+            self.updateFinishedTests.emit(self.finished_tests) #Obsolete ATOC: return all(passed)
         except Exception as err:
             logger.error(err)
     
@@ -742,8 +801,18 @@ class TestHandler(QObject):
             # Find all matching files
             matching_files = glob.glob(search_pattern)
 
+            if len(matching_files)==0:
+                raise Exception(f"Failed to copy root file to output directory. \
+Module disconnection detected because felis didn't \
+create {search_pattern}.")
+
             # Sort files by modification time (newest first)
             latest_file = max(matching_files, key=os.path.getmtime)
+
+            if os.path.getsize(latest_file)==0:
+                raise Exception(f"Failed to copy root file to output directory. \
+Module disconnection detected because {latest_file} \
+created by felis is empty.")
 
             # Copy the most recent file to the output directory
             os.system(f"cp {latest_file} {output_dir}/")
@@ -756,18 +825,23 @@ class TestHandler(QObject):
 
         try:
             if self.RunNumber == "-1":
-
-                self.copyMostRecentRootFile(000000,os.environ.get("PH2ACF_BASE_DIR")+"/test/Results",self.output_dir,self.currentTest)
-
+                self.copyMostRecentRootFile('000000',os.environ.get("PH2ACF_BASE_DIR")+"/test/Results",self.output_dir,self.currentTest)
                 # os.system("cp {0}/test/Results/Run000000*.txt {1}/".format(os.environ.get("PH2ACF_BASE_DIR"),self.output_dir))
                 # os.system("cp {0}/test/Results/Run000000*.xml {1}/".format(os.environ.get("PH2ACF_BASE_DIR"),self.output_dir))
-
             else:
                 self.copyMostRecentRootFile(self.RunNumber,os.environ.get("PH2ACF_BASE_DIR")+"/test/Results",self.output_dir,self.currentTest)
                 # os.system("cp {0}/test/Results/Run{1}*.txt {2}/".format(os.environ.get("PH2ACF_BASE_DIR"),self.RunNumber,self.output_dir))
                 # os.system("cp {0}/test/Results/Run{1}*.xml {2}/".format(os.environ.get("PH2ACF_BASE_DIR"),self.RunNumber,self.output_dir))
-        except:
-            print("Failed to copy file to output directory")
+
+        except Exception as e:
+            if str(e).startswith("Failed to copy root file to output directory."):
+                print(e)
+                logger.error(str(e))
+                self.forceContinue()
+                return True #if fail is due to connection issues
+            else:
+                print("Failed to copy file to output directory")
+        return False #if fail is due to connection issues
 
     #######################################################################
     ##  For real-time terminal display
@@ -1014,14 +1088,13 @@ class TestHandler(QObject):
         EnableReRun = False
 
         # Save the output ROOT file to output_dir
-        self.saveTest()
+        connectionFail = self.saveTest()
 
         # validate the results
         
-        status = self.validateTest()
+        self.validateTest(connectionFail)
         
-        if self.ProgressValue > 90:  #FIXME: This is a hack to get around the progress bar not updating.  Need to make this == 100 eventually
-            self.testIndexTracker += 1
+        self.testIndexTracker += 1
 
         # Will send signal to turn off power supply after composite or single tests are run
         if isCompositeTest(self.info):
@@ -1051,14 +1124,6 @@ class TestHandler(QObject):
             self.updateResult.emit((step, self.figurelist))
 
         # self.update()
-            
-
-        if (
-            status == False
-            and isCompositeTest(self.info)
-            and self.testIndexTracker < len(CompositeTests[self.info])
-        ):
-            self.forceContinue()
 
         if isCompositeTest(self.info):
             self.runTest()
@@ -1196,7 +1261,7 @@ class TestHandler(QObject):
             
             self.figurelist[moduleName] = [filename]
 
-        status = self.validateTest()
+        self.validateTest()
 
         step="IVCurve"
 
@@ -1234,13 +1299,6 @@ class TestHandler(QObject):
         else: 
             self.updateIVResult.emit((step, self.figurelist))  ##Add else statement to add signal in simple mode
 
-        if (
-            status == False
-            and isCompositeTest(self.info)
-            and self.testIndexTracker < len(CompositeTests[self.info])
-        ):
-            self.forceContinue()
-
         if isCompositeTest(self.info):
             self.runTest()
 
@@ -1258,7 +1316,7 @@ class TestHandler(QObject):
         
             SLDO_CSV_to_ROOT(moduleName, module_canvas_path, self.SLDOfilelist, self.output_dir)
 
-        status = self.validateTest()
+        self.validateTest()
         self.testIndexTracker += 1
 
         EnableReRun = False
@@ -1296,13 +1354,6 @@ class TestHandler(QObject):
         else: 
             self.updateSLDOResult.emit(("SLDOScan", self.figurelist))  ##Add else statement to add signal in simple mode
 
-        if (
-            status == False
-            and isCompositeTest(self.info)
-            and self.testIndexTracker < len(CompositeTests[self.info])
-        ):
-            self.forceContinue()
-
         if isCompositeTest(self.info):
             self.runTest()
 
@@ -1331,10 +1382,9 @@ class TestHandler(QObject):
             self.starttime = None
         elif msg_box.clickedButton() == retry_button:
             self.outputString.emit(f'Retrying {self.currentTest}...')
-            self.testIndexTracker = CompositeTests[self.info].index(self.currentTest)
-            self.runwindow.ResultWidget.runtime[self.testIndexTracker].setText("")
-            self.runwindow.ResultWidget.ProgressBar[self.testIndexTracker].setValue(0)
-            QApplication.processEvents() #not ideal. May need to fix later.
+            self.runwindow.ResultWidget.runtime[self.testIndexTracker].setText("") #may need to .update()
+            self.runwindow.ResultWidget.ProgressBar[self.testIndexTracker].setValue(0) #may need to .update(). Automatically adds "0%" text on Progress bar.
+            self.testIndexTracker -= 1
         elif msg_box.clickedButton() == continue_button:
             return
 

--- a/Gui/python/TestHandler.py
+++ b/Gui/python/TestHandler.py
@@ -80,8 +80,8 @@ class TestHandler(QObject):
     updateValidation = pyqtSignal(object)
     updateFinishedTests = pyqtSignal(object)
     powerSignal = pyqtSignal()
-    updateRampBar = pyqtSignal(QProgressBar, int, str)
-    uploadBarSignal = pyqtSignal(int, int)
+    updateProgressBar = pyqtSignal(QProgressBar, int, str)
+    uploadErrorSignal = pyqtSignal(str)
 
     def __init__(self, runwindow, master, info, firmware):
         super(TestHandler, self).__init__()
@@ -191,7 +191,15 @@ class TestHandler(QObject):
         self.updateSLDOResult.connect(self.runwindow.updateSLDOResult)
         self.updateValidation.connect(self.runwindow.updateValidation)
         self.updateFinishedTests.connect(self.runwindow.updateFinishedTests)
-        self.updateRampBar.connect(self.runwindow.updateRampBar)
+        self.updateProgressBar.connect(self.runwindow.updateProgressBar)
+        self.uploadErrorSignal.connect(lambda message :
+            QMessageBox.information(
+                None,
+                "Error",
+                message,
+                QMessageBox.Ok,
+            )
+        )
 
         self.finished_tests = []
 
@@ -389,8 +397,7 @@ class TestHandler(QObject):
             text = f'{np.abs(voltages[i])} V'          
             value = 100*np.abs(voltages[i]/max[i]) if max[i]!=0 else 0
 
-            self.updateRampBar.emit(self.runwindow.RampProgressBars[i], value, text)
-            QApplication.processEvents()
+            self.updateProgressBar.emit(self.runwindow.RampProgressBars[i], value, text)
 
     def runSingleTest(self, testName):
         print("Executing Single Step test...")
@@ -439,7 +446,8 @@ class TestHandler(QObject):
             #self.SLDOScanResult = ScanCanvas(self, xlabel="Voltage (V)", ylabel="I (A)")
             self.SLDOScanHandler = SLDOCurveHandler(self.instruments, moduleType=self.ModuleType[5:],
                                                     end_current=site_settings.ModuleCurrentMap[self.master.module_in_use],
-                                                    voltage_limit=site_settings.ModuleVoltageMapSLDO[self.master.module_in_use])
+                                                    voltage_limit=site_settings.ModuleVoltageMapSLDO[self.master.module_in_use],
+                                                    execute_each_step=self.ramp_progress_bar)
             self.SLDOScanHandler.makeplotSignal.connect(self.makeSLDOPlot)
             self.SLDOScanHandler.finishedSignal.connect(self.SLDOScanFinished)
             self.SLDOScanHandler.progressSignal.connect(self.updateProgress)
@@ -1406,17 +1414,15 @@ created by felis is empty.")
         self.force_continue_window.exec_()  # This will block until the window is closed
 
     def upload_to_Panthera(self):
-        self.runwindow.UploadButton.setDisabled(True)
-        counter = 0
-        nummodules = len(self.modules)
+        self.updateProgressBar.emit(self.runwindow.UploadProgressBar,
+                                        0,
+                                        f'{0}/{len(self.modules)} uploaded')
         try:
 
             self.runwindow.UploadButton.setDisabled(True)
             counter = 0
-            nummodules = len(self.modules)
 
             for module in self.modules:
-                self.uploadBarSignal.emit(counter, nummodules)
                 status, message = self.felis.upload_results(
                     module.getModuleName(),
                     self.master.username,
@@ -1426,27 +1432,27 @@ created by felis is empty.")
                 )
                 if not status:
                     raise ConnectionError(message)
+                
                 counter+=1
-
-            self.runwindow.ProgressBarLabel.setText("Upload successful!")
+                self.updateProgressBar.emit(self.runwindow.UploadProgressBar,
+                                        100*counter/len(self.modules),
+                                        f'{counter}/{len(self.modules)} uploaded')
 
         except ConnectionError as e:
-            error_message = repr(e) if len(repr(e))<100 else repr(e)[:100]+"..."
+            error_message = repr(e)
        
         except Exception as e:
             if not self.master.panthera_connected:
                 error_message = "Cannot upload test results, you are not signed in to Panthera."
-                logger.error(error_message)
             else:
-                error_message = "There was an error uploading the test results."
-                logger.error(f"{error_message} {repr(e)}")
+                error_message = repr(e)
                 self.runwindow.UploadButton.setDisabled(False)
                 if self.autoSave:
                     self.runwindow.UploadButton.setDisabled(False) #if autosave fails, allow manual
 
-            self.runwindow.ProgressBarLabel.setText(error_message)
+        logger.error(error_message)
+        self.uploadErrorSignal.emit(error_message)
             
-
     def bumpbond_analysis(self):
         
         runNumber = "000000" if self.RunNumber == "-1" else self.RunNumber

--- a/Gui/python/TestHandler.py
+++ b/Gui/python/TestHandler.py
@@ -87,7 +87,6 @@ class TestHandler(QObject):
         super(TestHandler, self).__init__()
         self.master = master
         self.instruments = self.master.instruments
-        print(self.instruments)
         self.mod_dict={}
         self.fused_dict_index=[-1,-1]
         # self.LVpowersupply.Reset()
@@ -195,8 +194,6 @@ class TestHandler(QObject):
         self.updateRampBar.connect(self.runwindow.updateRampBar)
 
         self.finished_tests = []
-        self.ramp_counter=1
-        self.current_bar=0
 
         self.initializeRD53Dict()
 
@@ -383,24 +380,17 @@ class TestHandler(QObject):
         #    updatedGlobalValue[1] = stepWiseGlobalValue[self.testIndexTracker]
         self.runSingleTest(testName)
 
-    def ramp_progress_bar(self, rampUp, step_size, voltage): #might be a more elegant way to do this
-        
-        if self.ramp_counter==1 and self.current_bar==0:
-            if rampUp==False: self.sweep_distances = [getattr(module["hv"], "voltage") for module in self.instruments._module_dict.values()]
+    def ramp_progress_bar(self, max): #might be a more elegant way to do this
 
-        step_size = list(self.instruments._module_dict.values())[self.current_bar]["hv"].default_step_size if step_size==None else step_size
-        sweep_distance = voltage if rampUp else self.sweep_distances[self.current_bar]
-        range = np.abs(int(sweep_distance/step_size))
+        voltages = [getattr(module["hv"], "voltage") for module in self.instruments._module_dict.values()]
 
-        if self.ramp_counter>range:
-            self.current_bar = (self.current_bar + 1)%len(self.instruments._module_dict.values())
-            self.ramp_counter = 1
-            return
+        for i in range(len(self.runwindow.RampProgressBars)):
 
-        value = int(100*self.ramp_counter/range if rampUp else 100*(1- (self.ramp_counter/range)))
-        text = f'{step_size*self.ramp_counter} V' if rampUp else f'{np.abs(self.sweep_distances[self.current_bar])-step_size*self.ramp_counter} V'
-        self.updateRampBar.emit(self.runwindow.RampProgressBars[self.current_bar], value, text)
-        self.ramp_counter += 1
+            text = f'{np.abs(voltages[i])} V'          
+            value = 100*np.abs(voltages[i]/max[i]) if max[i]!=0 else 0
+
+            self.updateRampBar.emit(self.runwindow.RampProgressBars[i], value, text)
+            QApplication.processEvents()
 
     def runSingleTest(self, testName):
         print("Executing Single Step test...")
@@ -470,18 +460,19 @@ class TestHandler(QObject):
 
             if testName == "SCurveScan_2100_FWD":
                 if hv_on:
-                    self.instruments.hv_off(step_size=self.step_size, execute_each_step=lambda : self.execute_each_step(False, self.step_size, (getattr(module["hv"], "voltage") for module in self.instruments._module_dict.values()) ))
+                    starting_voltages = [np.abs(getattr(module["hv"], "voltage")) for module in self.instruments._module_dict.values()]
+                    self.instruments.hv_off(execute_each_step=lambda : self.ramp_progress_bar(starting_voltages))
                     self.instruments.hv_on(voltage=site_settings.forward_bias_voltage, delay=0.3, step_size=10,
-                                           execute_each_step=lambda:self.ramp_progress_bar(True, 10, site_settings.forward_bias_voltage))
+                                           execute_each_step=lambda:self.ramp_progress_bar([site_settings.forward_bias_voltage]*len(self.instruments._module_dict.values())))
                 else:
                     self.instruments.hv_on(voltage=site_settings.forward_bias_voltage, delay=0.3, step_size=10,
-                                           execute_each_step=lambda:self.ramp_progress_bar(True, 10, site_settings.forward_bias_voltage))
+                                           execute_each_step=lambda:self.ramp_progress_bar([site_settings.forward_bias_voltage]*len(self.instruments._module_dict.values())))
                 testName = "SCurveScan_2100"
                 hv_on = True
             if not hv_on:
                 self.instruments.hv_on(
                     voltage=default_hv_voltage, delay=0.3, step_size=10,
-                    execute_each_step=lambda:self.ramp_progress_bar(True, 10, default_hv_voltage)
+                    execute_each_step=lambda:self.ramp_progress_bar([default_hv_voltage]*len(self.instruments._module_dict.values()))
                 )
 
         self.tempHistory = [0.0] * self.numChips
@@ -698,60 +689,6 @@ class TestHandler(QObject):
         self.haltSignal.emit(self.halt)
         self.starttime = None
 
-    def getExplanation(self,rowNum):
-        n=0
-        moduleName = self.failtable.item(rowNum,0).text()
-        for test_results in self.runwindow.modulestatus:
-            for module_result in test_results:
-                if module_result[moduleName][0]==False:
-                    n+=1
-                    if n==rowNum:
-                        return module_result[moduleName][1]
-        return "Could not retrieve additional information."
-
-    def errorPopup(self, module_name):
-        if hasattr(self, "fail_window")==False:
-            self.fail_window = QWidget()  # Create a regular window instead of QDialog
-            self.fail_window.setWindowTitle("Failed Tests")
-            self.fail_window.setGeometry(150, 150, 400, 250)
-
-            self.failtable = QTableWidget(1, 2)  # Ensure at least 1 row
-            self.failtable.itemClicked.connect(lambda : QMessageBox.information(
-                None, "Additional Information", self.getExplanation(item.row())
-                , QMessageBox.Ok))
-            #Should instead connect itemClicked to runwindow.displayTestResultPopup
-
-            self.failtable.setShowGrid(False)
-
-            # Set bold font for headers
-            bold_font = QFont()
-            bold_font.setBold(True)
-
-            headers = ["Module", "Test"]
-            for col, text in enumerate(headers):
-                item = QTableWidgetItem(text)
-                item.setFont(bold_font)
-                self.failtable.setItem(0, col, item)
-
-            button = QPushButton("OK", self.fail_window)
-            button.clicked.connect(self.fail_window.close)  # Close window when clicked
-
-            layout = QVBoxLayout()
-            layout.addWidget(self.failtable)
-            layout.addWidget(button)
-            self.fail_window.setLayout(layout)
-
-            self.fail_window.show()
-        
-        row_num=self.failtable.rowCount()
-        self.failtable.insertRow(row_num)
-        self.failtable.setItem(row_num,0,QTableWidgetItem(module_name))
-        self.failtable.setItem(row_num,1,QTableWidgetItem(self.currentTest))
-        item = self.failtable.item(row_num,0)
-        self.failtable.resizeColumnsToContents()
-        self.fail_window.resize(
-            sum((self.failtable.columnWidth(i) for i in range(self.failtable.columnCount())))+50,self.fail_window.height())
-
     def validateTest(self): #ATOC = At time of commit
         self.finished_tests.append(self.currentTest)
         try:
@@ -776,17 +713,13 @@ class TestHandler(QObject):
                             self.testIndexTracker, runNumber, module_data
                         )
 
-                        #Checks if the test failed and that test sequence hasn't already been quit
-                        if list(result.values())[0][0]==False and self.halt==False: #Need to check that it didnt disconnect
-                            self.errorPopup(list(result.keys())[0])
-
                         results.append(result)
                         passed.append(list(result.values())[0][0])
                                                 
                         self.figurelist[module.getModuleName()] = self.collect_plots(module.getModuleName())
             
             self.updateValidation.emit(results)
-            self.updateFinishedTests.emit(self.finished_tests) #Obsolete ATOC: return all(passed)
+            self.updateFinishedTests.emit(self.finished_tests) #Obsolete ATOC: "return all(passed)"
         except Exception as err:
             logger.error(err)
     
@@ -881,8 +814,6 @@ created by felis is empty.")
         textline = alltext.split("\n")
         # fileLines = open(self.outputFile,"r")
         # textline = fileLines.readlines()
-
-        print(alltext)
 
         for textStr in textline:
             import re
@@ -1082,24 +1013,21 @@ created by felis is empty.")
         self.outputfile.close()
         # While the process is killed:
 
-        print(2)
         if self.halt == True:
             self.haltSignal.emit(True)
             return
-        print(3)
+
         if self.run_process.state() == QProcess.Running:
             print("process is still running...  Attempting to terminate before next test.")
             self.run_process.terminate()
             if not self.run_process.waitForFinished(3000):
                 print('process would not terminate, so killing it now...')
                 self.run_process.kill()
-        print(4)
+
         if "IVCurve" in self.currentTest:
             self.saveTest()
             return
         
-        print(5)
-
         #Might need this if statment if we do the bumpbond analysis in the GUI.  If done in felis we can remove this.
         #if "PixelAlive_uncoupled" in self.currentTest:
         #    self.bumpbond_analysis()
@@ -1157,11 +1085,10 @@ created by felis is empty.")
         if measurementType=='IVCurve':
             self.IVProgressValue += stepSize/2.0
             self.runwindow.ResultWidget.ProgressBar[self.testIndexTracker].setValue(self.IVProgressValue)
-            self.runwindow.RampProgressBars[self.current_bar].setValue(self.IVProgressValue) #may run into issues if multiple hv's
+            self.ramp_progress_bar([site_settings.IVcurve_range if site_settings.IVcurve_range<0 else 80]*len(self.instruments._module_dict.values()))
         if 'SLDO' in measurementType:
             self.SLDOProgressValue += stepSize
             self.runwindow.ResultWidget.ProgressBar[self.testIndexTracker].setValue(self.SLDOProgressValue)
-            self.runwindow.RampProgressBars[self.current_bar].setValue(self.SLDOProgressValue) #may run into issues if multiple hv's
 
     # def updateMeasurement(self, measureType, measure):
     #     """
@@ -1306,7 +1233,7 @@ created by felis is empty.")
                 delay=0.3,
                 step_size=3,
                 measure=False,
-                execute_each_step=lambda:self.ramp_progress_bar(True, 3, default_hv_voltage)
+                execute_each_step=lambda:self.ramp_progress_bar([default_hv_voltage]*len(self.instruments._module_dict.values()))
             )
 
             if self.testIndexTracker == len(CompositeTests[self.info]):
@@ -1362,7 +1289,7 @@ created by felis is empty.")
                 delay=0.3,
                 step_size=5,
                 measure=False,
-                execute_each_step=lambda:self.ramp_progress_bar(True, 5, default_hv_voltage)
+                execute_each_step=lambda:self.ramp_progress_bar([default_hv_voltage]*len(self.instruments._module_dict.values()))
             )
 
             if self.testIndexTracker == len(CompositeTests[self.info]):
@@ -1447,7 +1374,6 @@ created by felis is empty.")
 
         # Define button handlers
         def handle_close(event):
-            print(f'self.force_continue_window.abort {self.force_continue_window.abort}')
             if self.force_continue_window.abort==True:
                 self.run_process.kill()
                 self.halt = True
@@ -1476,9 +1402,7 @@ created by felis is empty.")
         retry_button.clicked.connect(handle_retry)
         continue_button.clicked.connect(handle_continue)
 
-        
         self.force_continue_window.closeEvent = handle_close
-        self.force_continue_window.show()
         self.force_continue_window.exec_()  # This will block until the window is closed
 
     def upload_to_Panthera(self):

--- a/Gui/python/TestHandler.py
+++ b/Gui/python/TestHandler.py
@@ -729,7 +729,7 @@ class TestHandler(QObject):
         self.fail_window.resize(
             sum((self.failtable.columnWidth(i) for i in range(self.failtable.columnCount())))+50,self.fail_window.height())
 
-    def validateTest(self, connectionFail): #ATOC = At time of commit
+    def validateTest(self): #ATOC = At time of commit
         self.finished_tests.append(self.currentTest)
         try:
             passed = []
@@ -753,7 +753,7 @@ class TestHandler(QObject):
                             self.testIndexTracker, runNumber, module_data
                         )
 
-                        if list(result.values())[0][0]==False and connectionFail==False:
+                        if list(result.values())[0][0]==False: #Need to check that it didnt disconnect
                             self.errorPopup(list(result.keys())[0])
 
                         results.append(result)
@@ -838,10 +838,8 @@ created by felis is empty.")
                 print(e)
                 logger.error(str(e))
                 self.forceContinue()
-                return True #if fail is due to connection issues
             else:
                 print("Failed to copy file to output directory")
-        return False #if fail is due to connection issues
 
     #######################################################################
     ##  For real-time terminal display
@@ -1088,11 +1086,11 @@ created by felis is empty.")
         EnableReRun = False
 
         # Save the output ROOT file to output_dir
-        connectionFail = self.saveTest()
+        self.saveTest()
 
         # validate the results
         
-        self.validateTest(connectionFail)
+        self.validateTest()
         
         self.testIndexTracker += 1
 

--- a/Gui/python/TestValidator.py
+++ b/Gui/python/TestValidator.py
@@ -7,7 +7,7 @@ from Gui.python.logging_config import logger
 from InnerTrackerTests.TestSequences import Test_to_Ph2ACF_Map
 from InnerTrackerTests.Analysis.IVCurve_CSV_to_ROOT import IVCurve_CSV_to_ROOT
 
-def ResultGrader(felis, outputDir, testName, testIndexInSequence, runNumber, module_data):
+def ResultGrader(felis, outputDir, testName, testIndexInSequence, runNumber, module_data, BBanalysis_root_files):
     try:
         module_name = module_data['module'].getModuleName()
         module_type = module_data['module'].getModuleType()
@@ -15,15 +15,6 @@ def ResultGrader(felis, outputDir, testName, testIndexInSequence, runNumber, mod
         if 'SLDOScan' in testName or 'CommunicationTest' in testName:
             explanation = 'No grading currently available for SLDOScan or CommunicationTest.'
             return {module_name:(True, explanation)}
-        
-        #if 'IVCurve' in testName:
-        #    module_canvas_path = "Detector/Board_{boardID}/OpticalGroup_{ogID}/Hybrid_{hybridID}/".format(
-        #        boardID=module_data['boardID'], 
-        #        ogID=module_data['ogID'], 
-        #        hybridID=module_data['hybridID'])
-        #    relevant_files = [outputDir+"/"+os.fsdecode(file) for file in os.listdir(outputDir)]
-
-   
 
         root_file_name = testName.split('_')[0]
         if 'SCurveScan' in root_file_name:
@@ -40,19 +31,14 @@ def ResultGrader(felis, outputDir, testName, testIndexInSequence, runNumber, mod
                 hybridID=module_data['hybridID'])
             ROOT_file_path = "{0}/Result_{1}.root".format(outputDir, root_file_name)
 
+            if root_file_name in ("PixelAlive_highcharge_xtalk","PixelAlive_coupled_xtalk","PixelAlive_uncoupled_xtalk"):
+                BBanalysis_root_files.append(ROOT_file_path)
+
             relevant_files = [outputDir+"/"+os.fsdecode(file) for file in os.listdir(outputDir)]
             _1, _2 = felis.set_module(
                 module_name, module_type.split(" ")[0], module_type.split(" ")[2].replace("Quad","2x2"), module_version.strip('v'), True, "link"
             )
             module_canvases = [module_canvas_path]
-            #status, message, sanity, explanation = felis.set_result(
-            #    ROOT_file_path,
-            #    module_canvases,
-            #    relevant_files,
-            #    module_name,
-            #    f"{testIndexInSequence:02d}_{testName}",
-            #    'ivcurve',
-            #)
             status, message, sanity, explanation = felis.set_result(
                 relevant_files,
                 module_name,
@@ -63,6 +49,8 @@ def ResultGrader(felis, outputDir, testName, testIndexInSequence, runNumber, mod
             ROOT_file_path = "{0}/Run{1}_{2}.root".format(
                 outputDir, runNumber, root_file_name
             )
+            if root_file_name in ("PixelAlive_highcharge_xtalk","PixelAlive_coupled_xtalk","PixelAlive_uncoupled_xtalk"):
+                BBanalysis_root_files.append(ROOT_file_path)
             chip_canvas_path_template = "Detector/Board_{boardID}/OpticalGroup_{ogID}/Hybrid_{hybridID}/Chip_{chipID:02d}"
             active_chips = [chip.getID() for chip in module_data['module'].getChips().values() if chip.getStatus()]
             chip_canvases = [
@@ -80,8 +68,6 @@ def ResultGrader(felis, outputDir, testName, testIndexInSequence, runNumber, mod
             )
 
             status, message, sanity, explanation = felis.set_result(
-                #ROOT_file_path,
-                #chip_canvases,
                 relevant_files,
                 module_name,
                 f"{testIndexInSequence:02d}_{testName}",
@@ -90,8 +76,7 @@ def ResultGrader(felis, outputDir, testName, testIndexInSequence, runNumber, mod
         if not status:
             raise RuntimeError(message)
                 
-        #return {module_name:(sanity, explanation)}
-        return {module_name:(True, explanation)}
+        return {module_name:(True, explanation)}, BBanalysis_root_files
     except Exception as err:
         #logger.error("An error was thrown while grading: {}".format(repr(err)))
-        return {module_name:(False, repr(err))}
+        return {module_name:(False, repr(err))}, BBanalysis_root_files

--- a/run_Docker.sh
+++ b/run_Docker.sh
@@ -37,7 +37,8 @@ echo $mydevices | xargs
 if [[ $mode == "dev" ]] 
 then
     echo "running as $mode"
-    docker run --detach-keys='ctrl-e,e' --rm -ti $mydevices -v ${PWD}:/home/cmsTkUser/Ph2_ACF_GUI\
+    docker run --detach-keys='ctrl-e,e' --rm -ti $mydevices -v ${PWD}:${PWD}\
+		-v ${PWD}/icicle/icicle:/home/cmsTkUser/Ph2_ACF_GUI/icicle/icicle:ro\
 		-v ${PWD}/Gui/siteConfig.py:/home/cmsTkUser/Ph2_ACF_GUI/Gui/siteSettings.py\
 		-v ${PWD}/Ph2_ACF/test:/home/cmsTkUser/Ph2_ACF_GUI/Ph2_ACF/test\
 		-v ${PWD}/Ph2_ACF/settings/RD53Files:/home/cmsTkUser/Ph2_ACF_GUI/Ph2_ACF/settings/RD53Files\
@@ -51,9 +52,8 @@ then
 		-v ${PWD}/FirmwareImages:/home/cmsTkUser/Ph2_ACF_GUI/FirmwareImages/\
 		-v ${PWD}/symlinks.sh:/home/cmsTkUser/Ph2_ACF_GUI/symlinks.sh/\
 		-v ${PWD}/Gui/jsonFiles/:/home/cmsTkUser/Ph2_ACF_GUI/Gui/jsonFiles/\
-		-w $PWD  -e DISPLAY=$DISPLAY\
+		-w ${PWD} -e DISPLAY=$DISPLAY\
 		--volume="$HOME/.Xauthority:/root/.Xauthority:rw" --net host majoyce2/ph2_acf_gui_dev:latest 
-
 else
     echo "running as user"
 	IMAGE_NAME="majoyce2/ph2_acf_gui_user:latest"
@@ -90,13 +90,15 @@ To install on Alma Linux please run:\e[0m
     		echo "Image pull canceled."
   		fi
 	fi
-    docker run --detach-keys='ctrl-e,e' --rm -ti $mydevices\
+    docker run --detach-keys='ctrl-e,e' --rm -ti $mydevices -v ${PWD}:${PWD}\
 		-v ${PWD}/Gui/siteConfig.py:/home/cmsTkUser/Ph2_ACF_GUI/Gui/siteSettings.py\
 		-v ${PWD}/Ph2_ACF/test:/home/cmsTkUser/Ph2_ACF_GUI/Ph2_ACF/test\
 		-v ${PWD}/data:/home/cmsTkUser/Ph2_ACF_GUI/data\
-    -v ${PWD}/Gui/jsonFiles:/home/cmsTkUser/Ph2_ACF_GUI/Gui/jsonFiles\
-		-w /home/cmsTkUser/Ph2_ACF_GUI  -e DISPLAY=$DISPLAY\
-    --volume="$HOME/.Xauthority:/root/.Xauthority:rw" --net host majoyce2/ph2_acf_gui_user:latest #local/testimagejuly30user
+        -v ${PWD}/Gui/jsonFiles:/home/cmsTkUser/Ph2_ACF_GUI/Gui/jsonFiles\
+		-v ${PWD}/Gui/QtGUIutils/PeltierCoolingApp.py:/home/cmsTkUser/Ph2_ACF_GUI/Gui/QtGUIutils/PeltierCoolingApp.py\
+        -v ${PWD}/Gui/python/Peltier.py:/home/cmsTkUser/Ph2_ACF_GUI/Gui/python/Peltier.py\
+		-w $PWD  -e DISPLAY=$DISPLAY\
+		--volume="$HOME/.Xauthority:/root/.Xauthority:rw" --net host majoyce2/ph2_acf_gui_user:latest #local/testimagejuly30user
 		#Before, the docker run command had the options -v $XSOCK:$XSOCK -v $XAUTH:$XAUTH -e XAUTHORITY=$XAUTH. We were having trouble
 		#running the GUI through SSH connections, so we removed those options and added --volume="$HOME/.Xauthority:/root/.Xauthority:rw"
 		#which seemed to fix the issue of running the GUI from SSH connections. At the time of this commit, we have no idea why this fixed it


### PR DESCRIPTION
Made run_process and info_process in TestHandler a list of processes for each fc7. It now creates a CMSIT_"fc7".xml file instead of CMSIT.xml
file. There's also two terminals for each run_process.

I also added some minor changes in TestValidator and TestHandler so that when it get's a test with "analyze" in the name, it DOESN'T run a test,
and instead just runs TestValidator.

TODO! the image resulting from setResult in TestValidator should pop up in the file tree widget in runwindow, but it doesn't and I'm not totally
sure how to do it.

I also deleted a fair amount of commented-out code because it was bothering me.