### PR TITLE
Conditional Monitoring

### DIFF
--- a/Gui/GUIutils/guiUtils.py
+++ b/Gui/GUIutils/guiUtils.py
@@ -441,7 +441,10 @@ def GenerateXMLConfig(BeBoard, testName, outputDir, **arg):
     if "RD53A" in boardtype:
         MonitoringModule0.SetMonitoringList(MonitoringListA)
     else:
-        MonitoringModule0.SetMonitoringList(Monitoring_DictB[testName])
+        if testName in Monitoring_DictB:
+            MonitoringModule0.SetMonitoringList(Monitoring_DictB[testName])
+        else:
+            MonitoringModule0.SetMonitoringList({})
     HWDescription0.AddMonitoring(MonitoringModule0)
     GenerateHWDescriptionXML(HWDescription0, outputFile, boardtype)
 


### PR DESCRIPTION
We would only like to enable Ph2_ACF monitoring for IV curves and SLDO_GADC scans. This pull request ensures that monitoring is only enabled for these tests. 

This pull request requires the following pull request to be approved in inner-tracker-tests to be approved as well.
https://gitlab.cern.ch/cms_tk_ph2/inner-tracker-tests/-/merge_requests/48