### PR TITLE
Cooler ryan

### DIFF
--- a/Gui/python/IVCurveHandler.py
+++ b/Gui/python/IVCurveHandler.py
@@ -46,7 +46,6 @@ class IVCurveThread(QThread):
             execute_each_step=lambda: self.execute_each_step(starting_voltages)
         )
         self.instruments.hv_on(voltage=0, delay=0.5, step_size=10, no_lock=True)
-        self.instruments.hv_set_ocp(0.00001)
 
     # Used to break out of hv_on correctly
     def breakTest(self):

--- a/Gui/python/IVCurveHandler.py
+++ b/Gui/python/IVCurveHandler.py
@@ -2,7 +2,6 @@ from PyQt5.QtCore import QThread, QObject, pyqtSignal
 
 import numpy as np
 from Gui.python.logging_config import logger
-from Gui.siteSettings import IVcurve_range
 import Gui.siteSettings as site_settings
 
 
@@ -27,8 +26,8 @@ class IVCurveThread(QThread):
         self.startVal = 0
         self.target = 0
         # Making sure IVcurve peak is a negative voltage
-        if IVcurve_range[testName] < 0:
-            self.stopVal = IVcurve_range[testName]
+        if site_settings.IVcurve_range[testName] < 0:
+            self.stopVal = site_settings.IVcurve_range[testName]
             print("IVcurve range: ", self.stopVal)
         else:
             self.stopVal = -80

--- a/Gui/python/IVCurveHandler.py
+++ b/Gui/python/IVCurveHandler.py
@@ -3,6 +3,7 @@ from PyQt5.QtCore import QThread, QObject, pyqtSignal
 import numpy as np
 from Gui.python.logging_config import logger
 from Gui.siteSettings import IVcurve_range
+import Gui.siteSettings as site_settings
 
 
 class IVCurveThread(QThread):
@@ -45,6 +46,7 @@ class IVCurveThread(QThread):
             execute_each_step=lambda: self.execute_each_step(starting_voltages)
         )
         self.instruments.hv_on(voltage=0, delay=0.5, step_size=10, no_lock=True)
+        self.instruments.hv_set_ocp(0.00001)
 
     # Used to break out of hv_on correctly
     def breakTest(self):
@@ -98,10 +100,11 @@ class IVCurveHandler(QObject):
     progressSignal = pyqtSignal(str, float)
     startSignal = pyqtSignal()
 
-    def __init__(self, testName, instrument_cluster, execute_each_step):
+    def __init__(self, testName, instrument_cluster, nextTest, execute_each_step):
         super(IVCurveHandler, self).__init__()
         self.instruments = instrument_cluster
         self.execute_each_step = execute_each_step
+        self.nextTest = nextTest
 
         assert self.instruments is not None, logger.debug(
             "Error instantiating instrument cluster"
@@ -136,9 +139,15 @@ class IVCurveHandler(QObject):
             np.abs(getattr(module["hv"], "voltage"))
             for module in self.instruments._module_dict.values()
         ]
-        self.instruments.hv_off(
-            execute_each_step=lambda: self.execute_each_step(starting_voltages)
-        )
+        ## Will Set voltage to default unless SLDO is the next test
+        if (self.nextTest is not None) and ("SLDO" not in self.nextTest): 
+            self.instruments.hv_set(voltage = site_settings.icicle_instrument_setup[
+                    "instrument_dict"]["hv"]["default_voltage"], delay = 0.3, step_size = 10
+                )
+        else:    
+            self.instruments.hv_off(
+                execute_each_step=lambda: self.execute_each_step(starting_voltages)
+            )    
         self.finished.emit(test, measure)
 
     def stop(self):

--- a/Gui/python/TestHandler.py
+++ b/Gui/python/TestHandler.py
@@ -20,7 +20,6 @@ import time
 from datetime import datetime
 import numpy as np
 import matplotlib.pyplot as plt
-import cProfile
 
 from Gui.GUIutils.settings import (
     ModuleLaneMap,
@@ -376,7 +375,6 @@ class TestHandler(QObject):
             nextTest = runTestList[self.testIndexTracker + 1]
         else:
             nextTest = None  
-        print("\n\n Next test: {}".format(nextTest))
         self.runSingleTest(testName, nextTest)
 
     def ramp_progress_bar(self, max):
@@ -392,7 +390,6 @@ class TestHandler(QObject):
             self.updateProgressBar.emit(self.runwindow.RampProgressBars[i], value, text)
 
     def runSingleTest(self, testName, nextTest = None):
-        print("\n\nRunning Test: {}".format(testName))
         if "analyze" in testName.lower():
             self.output_dir, self.input_dir = self.config_output_dir(testName)
             self.currentTest = testName

--- a/Gui/python/TestHandler.py
+++ b/Gui/python/TestHandler.py
@@ -20,6 +20,7 @@ import time
 from datetime import datetime
 import numpy as np
 import matplotlib.pyplot as plt
+import cProfile
 
 from Gui.GUIutils.settings import (
     ModuleLaneMap,
@@ -371,7 +372,12 @@ class TestHandler(QObject):
             self.testIndexTracker = 0
             return
         testName = runTestList[self.testIndexTracker]
-        self.runSingleTest(testName)
+        if self.testIndexTracker + 1 < len(runTestList):  # Check if there is a next test
+            nextTest = runTestList[self.testIndexTracker + 1]
+        else:
+            nextTest = None  
+        print("\n\n Next test: {}".format(nextTest))
+        self.runSingleTest(testName, nextTest)
 
     def ramp_progress_bar(self, max):
         voltages = [
@@ -385,7 +391,8 @@ class TestHandler(QObject):
 
             self.updateProgressBar.emit(self.runwindow.RampProgressBars[i], value, text)
 
-    def runSingleTest(self, testName):
+    def runSingleTest(self, testName, nextTest = None):
+        print("\n\nRunning Test: {}".format(testName))
         if "analyze" in testName.lower():
             self.output_dir, self.input_dir = self.config_output_dir(testName)
             self.currentTest = testName
@@ -427,6 +434,7 @@ class TestHandler(QObject):
             self.IVCurveHandler = IVCurveHandler(
                 self.currentTest,
                 self.instruments,
+                nextTest,
                 execute_each_step=self.ramp_progress_bar,
             )
             self.IVCurveHandler.finished.connect(self.IVCurveFinished)
@@ -1241,21 +1249,6 @@ created by Ph2_ACF is empty."
 
         # Will send signal to turn off power supply after composite or single tests are run
         if isCompositeTest(self.info):
-            default_hv_voltage = site_settings.icicle_instrument_setup[
-                "instrument_dict"
-            ]["hv"]["default_voltage"]
-            # assumes only 1 HV titled 'hv' in instruments.json
-
-            self.master.instruments.hv_on(
-                voltage=default_hv_voltage,
-                delay=0.3,
-                step_size=3,
-                measure=False,
-                execute_each_step=lambda: self.ramp_progress_bar(
-                    [default_hv_voltage] * len(self.instruments._module_dict.values())
-                ),
-            )
-
             if self.testIndexTracker == len(CompositeTests[self.info]):
                 self.powerSignal.emit()
                 EnableReRun = True


### PR DESCRIPTION
## Description
HV will now set voltage to default if IVCurve is followed by a Ph2_ACF test. If IVCurve is followed by SLDO or not followed by anything then HV will go to 0.

## Checklist
Before submitting this PR, please ensure the following:

- [X] I am using the **correct branches/versions** of all submodules.
- [X] I have successfully **launched the Simplified GUI**.
- [X] I have successfully **run a test in the Simplified GUI**.
- [X] I have successfully **run a test in the Expert GUI**.


## Changes Made
Added parameter nextTest to be passed to finish function in IVCurveHandler.py 
Added if statement to finish function to check nextTest and turn HV off or set HV to a voltage depending on nextTest
Added nextTest var to CompositeTest and SingleTest functions in TestHandler.py

## Testing
X	| check IV running first
X	| check IV curve alone
X	| check no IV curve single and multiple
X	| check weird voltages
X      | check SLDO after IV


