### PR TITLE
Simple GUI displays PNG files. Will not take SVG files

### DIFF
--- a/Gui/python/ROOTInterface.py
+++ b/Gui/python/ROOTInterface.py
@@ -123,6 +123,29 @@ def TCanvas2SVG(outputDir, canvas, name=None):
     return outputFile
 
 
+def TCanvas2PNG(outputDir, canvas, name=None):
+    ROOT.gStyle.SetPalette(57)
+    if not name:
+        seconds = time.time()
+        outputFile = outputDir + "/display{}.png".format(seconds)
+    else:
+        outputFile = outputDir + "/{}.png".format(name)
+    try:
+        canvas.SetBatch(ROOT.kTRUE)
+        canvas.Draw()
+        if "SCurve" in name:
+            canvas.SetLogz()
+        if "PixelAlive" in name:
+            ROOT.gStyle.SetOptStat(0)  # no statistics box
+        else:
+            ROOT.gStyle.SetOptStat(1111)  # default statistics box
+        canvas.Print(outputFile)
+        # canvas.Close()
+        logger.info(outputFile + " is saved")
+    except Exception as e:
+        logger.warning("Failed to save " + outputFile + "\nReason: " + str(e))
+    return outputFile
+
 def GetBinary(fileName):
     binaryData = ROOT.TFile(fileName)
     return binaryData

--- a/Gui/python/ResultTreeWidget.py
+++ b/Gui/python/ResultTreeWidget.py
@@ -1,7 +1,7 @@
 from PyQt5 import QtCore
-from PyQt5.QtCore import Qt, QTimer
+from PyQt5.QtCore import Qt, QTimer, QSize
 
-# from PyQt5.QtGui import QPixmap
+from PyQt5.QtGui import QPixmap
 from PyQt5.QtWidgets import (
     QGridLayout,
     QLabel,
@@ -12,7 +12,7 @@ from PyQt5.QtWidgets import (
     QTreeWidgetItem,
     QWidget
 )
-from PyQt5 import QtSvg
+# from PyQt5 import QtSvg
 
 import os
 import subprocess
@@ -21,9 +21,8 @@ import subprocess
 from Gui.GUIutils.guiUtils import isCompositeTest
 from Gui.python.ROOTInterface import (
     GetDirectory,
-    TCanvas2SVG,
+    TCanvas2PNG,
 )
-from Gui.QtGUIutils.QtTCanvasWidget import QtTCanvasWidget
 from Gui.python.logging_config import logger
 from InnerTrackerTests.TestSequences import CompositeTests
 
@@ -121,11 +120,11 @@ class ResultTreeWidget(QWidget):
             self.leftArrow = QPushButton("<-")
             self.leftArrow.clicked.connect(self.leftArrowFunc)
 
-            self.SVGWidget = QtSvg.QSvgWidget()
-            minHeight = 400
-            ratio = 1.5
-            self.SVGWidget.setMinimumHeight(minHeight)
-            self.SVGWidget.setMinimumWidth(minHeight * ratio)
+            self.DisplayLabel = QLabel()
+            self.DisplayLabel.setMinimumHeight(400)
+            self.DisplayLabel.setMinimumWidth(600)
+            self.DisplayLabel.setAlignment(Qt.AlignCenter)
+            self.mainLayout.addWidget(self.DisplayLabel, 1, 1+len(self.firmware), 9, 3)
 
         if self.master.expertMode:
             self.mainLayout.addWidget(self.OutputTree, 0, 1+len(self.firmware), 10, 2)
@@ -134,7 +133,7 @@ class ResultTreeWidget(QWidget):
             self.mainLayout.addWidget(self.ControlButtom, 0, 4+len(self.firmware), 1, 1)
             self.mainLayout.addWidget(self.rightArrow, 0, 3+len(self.firmware), 1, 1)
             self.mainLayout.addWidget(self.leftArrow, 0, 2+len(self.firmware), 1, 1)
-            self.mainLayout.addWidget(self.SVGWidget, 1, 1+len(self.firmware), 9, 3)
+            self.mainLayout.addWidget(self.DisplayLabel, 1, 1+len(self.firmware), 9, 3)
 
         if not self.master.expertMode:
             # Initialize timer:
@@ -223,8 +222,10 @@ class ResultTreeWidget(QWidget):
         self.displayIndex = self.displayIndex % len(self.displayList)
         step, displayPlot = self.displayList[self.displayIndex]
         self.TestLabel.setText("Step{}".format(step))
-        self.SVGWidget.load(displayPlot)
-
+        pixmap = QPixmap(displayPlot).scaled(
+            QSize(self.DisplayW, self.DisplayH), Qt.KeepAspectRatio, Qt.SmoothTransformation
+        )
+        self.DisplayLabel.setPixmap(pixmap)
     def rightArrowFunc(self):
         self.timer.start(3000)
         if len(self.displayList) > 0:
@@ -270,7 +271,7 @@ class ResultTreeWidget(QWidget):
 
     def updateIVResult(self, sourceFolder):
         process2 = subprocess.run(
-            'find {0} -type f -name "*IVCurve_Module_*.svg" '.format(sourceFolder),
+            'find {0} -type f -name "*IVCurve_Module_*.png" '.format(sourceFolder),
             shell=True,
             stdout=subprocess.PIPE,
         )
@@ -292,7 +293,7 @@ class ResultTreeWidget(QWidget):
 
     def updateSLDOResult(self, sourceFolder):
         process2 = subprocess.run(
-            'find {0} -type f -name "*.svg" '.format(sourceFolder),
+            'find {0} -type f -name "*.png" '.format(sourceFolder),
             shell=True,
             stdout=subprocess.PIPE,
         )
@@ -327,18 +328,18 @@ class ResultTreeWidget(QWidget):
             except OSError:
                 logger.warning("Failed to create " + tmpDir)
 
-        if "svg" in str(canvas):
-            svgFile = str(canvas)
+        if "png" in str(canvas):
+            pngFile = str(canvas)
         else:
-            svgFile = TCanvas2SVG(tmpDir, canvas, name)
-        self.displayingImage = svgFile
+            pngFile = TCanvas2PNG(tmpDir, canvas, name)
+        self.displayingImage = pngFile
 
         try:
-            # self.DisplayView = QPixmap(jpgFile).scaled(QSize(self.DisplayW,self.DisplayH), Qt.KeepAspectRatio, Qt.SmoothTransformation)
-            # self.DisplayLabel.setPixmap(self.DisplayView)
-            # self.update
-            self.Plot.append(QtTCanvasWidget(self.master, svgFile))
-            logger.info("Displaying " + svgFile)
+            pixmap = QPixmap(pngFile).scaled(
+                QSize(self.DisplayW, self.DisplayH), Qt.KeepAspectRatio, Qt.SmoothTransformation
+            )
+            self.DisplayLabel.setPixmap(pixmap)
+            logger.info("Displaying " + pngFile)
         except Exception as e:
-            logger.error("Failed to display " + svgFile + f"due to error {e}")
+            logger.error("Failed to display " + pngFile + f"due to error {e}")
         pass


### PR DESCRIPTION
## Description
Simple GUI displays PNG files in the Result Tree Widget now instead of displaying SVG files

## Checklist
Before submitting this PR, please ensure the following:

- [ X] I am using the **correct branches/versions** of all submodules.
- [ X] I have successfully **launched the Simplified GUI**.
- [ X] I have successfully **run a test in the Simplified GUI**.

## Changes Made
ResultTreeWidget.py now takes PNG files instead of SVG. Included a function in ROOTInterface for PNG files similar to the SVG TCanvas2SVG  function

## Testing
Ran functional test. Simple GUI looped through PNG graphs correctly.