### PR TITLE
TestHandlerEfficiency merge

### DIFF
--- a/Gui/python/TestHandler.py
+++ b/Gui/python/TestHandler.py
@@ -143,6 +143,7 @@ class TestHandler(QObject):
 
         self.runNext = threading.Event()
         self.testIndexTracker = 0
+        self.testsAttempted = 0
         self.listWidgetIndex = 0
         self.outputDirQueue = []
         # Fixme: QTimer to be added to update the page automatically
@@ -359,6 +360,7 @@ class TestHandler(QObject):
         if reRun:
             self.halt = False
             self.testIndexTracker = 0
+            self.testsAttempted = 0
         testName = self.info
 
         self.input_dir = self.output_dir
@@ -380,6 +382,7 @@ class TestHandler(QObject):
 
         if self.testIndexTracker == len(CompositeTests[self.info]):
             self.testIndexTracker = 0
+            self.testsAttempted = 0
             return
         testName = runTestList[self.testIndexTracker]
         if self.testIndexTracker + 1 < len(runTestList):  # Check if there is a next test
@@ -582,12 +585,36 @@ class TestHandler(QObject):
                         f"Running COMMAND: CMSITminiDAQ  -f  CMSIT_{firmware.getBoardName()}.xml  -p"
                     ],
                 )
-        else:
+        '''
+        if self.currentTest == ["exampletest"]:               #for tests needing -c
             for process, firmware in zip(self.info_processes, self.firmware):
                 process.start(
                     "echo",
                     [
                         "Running COMMAND: CMSITminiDAQ  -f  CMSIT_{0}.xml  -c  {1}".format(
+                            firmware.getBoardName(),
+                            Test_to_Ph2ACF_Map[self.currentTest],
+                        )
+                    ],
+                )        
+                    '''        
+        if self.testsAttempted == 0:
+            for process, firmware in zip(self.info_processes, self.firmware):
+                process.start(
+                    "echo",
+                    [
+                        "Running COMMAND: CMSITminiDAQ  -f  CMSIT_{0}.xml  -c  {1}".format(
+                            firmware.getBoardName(),
+                            Test_to_Ph2ACF_Map[self.currentTest],
+                        )
+                    ],
+                )        
+        else:
+            for process, firmware in zip(self.info_processes, self.firmware):
+                process.start(
+                    "echo",
+                    [
+                        "Running COMMAND: CMSITminiDAQ  -f  CMSIT_{0}.xml  -k -c  {1}".format(
                             firmware.getBoardName(),
                             Test_to_Ph2ACF_Map[self.currentTest],
                         )
@@ -613,6 +640,28 @@ class TestHandler(QObject):
                     "CMSITminiDAQ",
                     ["-f", f"CMSIT_{firmware.getBoardName()}.xml", "-p"],
                 )
+        #if self.currentTest == ["exampletest"]:               #for tests needing -c
+        #    for process, firmware in zip(self.run_processes, self.firmware):
+        #        process.start(
+        #            "CMSITminiDAQ",
+        #            [
+        #                "-f",
+        #                f"CMSIT_{firmware.getBoardName()}.xml",
+        #                "-c",
+        #                "{}".format(Test_to_Ph2ACF_Map[self.currentTest]),
+        #            ],
+        #        )
+        if self.testsAttempted == 0:
+            for process, firmware in zip(self.run_processes, self.firmware):
+                process.start(
+                    "CMSITminiDAQ",
+                    [
+                        "-f",
+                        f"CMSIT_{firmware.getBoardName()}.xml",
+                        "-c",
+                        "{}".format(Test_to_Ph2ACF_Map[self.currentTest]),
+                    ],
+                )
         else:
             for process, firmware in zip(self.run_processes, self.firmware):
                 process.start(
@@ -620,6 +669,7 @@ class TestHandler(QObject):
                     [
                         "-f",
                         f"CMSIT_{firmware.getBoardName()}.xml",
+                        "-k",
                         "-c",
                         "{}".format(Test_to_Ph2ACF_Map[self.currentTest]),
                     ],
@@ -633,6 +683,7 @@ class TestHandler(QObject):
         self.haltSignal.emit(self.halt)
 
         self.starttime = None
+        self.testsAttempted = 0 #reset when aborted for fresh restart
         if self.IVCurveHandler:
             for console in self.runwindow.ConsoleViews:
                 self.outputString.emit("Aborting IVCurve", console)
@@ -1077,6 +1128,7 @@ created by Ph2_ACF is empty."
         # Save the output ROOT file to output_dir
         self.saveTest(processIndex)
         self.testIndexTracker += 1
+        self.testsAttempted += 1
 
         # validate the results
         self.validateTest()
@@ -1274,6 +1326,7 @@ created by Ph2_ACF is empty."
         step = "IVCurve"
 
         self.testIndexTracker += 1
+        self.testsAttempted += 1
 
         EnableReRun = False
 
@@ -1321,6 +1374,7 @@ created by Ph2_ACF is empty."
 
         self.validateTest()
         self.testIndexTracker += 1
+        self.testsAttempted += 1
 
         EnableReRun = False
         # Will send signal to turn off power supply after composite or single tests are run


### PR DESCRIPTION
## Description
Small changes made to TestHandler.py to run tests with -k -c if they are not the first test in the sequence. 

## Checklist
Before submitting this PR, please ensure the following:

- [] I am using the **correct branches/versions** of all submodules.
- [] I have successfully **launched the Simplified GUI**.
- [] I have successfully **run a test in the Simplified GUI**.
- [] I have successfully **run a test in the Expert GUI**.

## Related Issues
<!-- List any related issues, e.g. "Fixes #123" or "Closes #456". -->

## Changes Made
Changed the command run for the 2nd+ test in a sequence to be run with -k -c for better efficiency. 

## Testing
Had issues at first but that is because I was needed to change what version of InnerTrackerTests I was on. Worked fine after both Ryans helped to fix that. 

## Additional Notes
<!-- Add any additional comments or context if needed. -->
