### PR TITLE
Simple GUI Runbutton turned off for no LV,HV,FC7 connections

### DIFF
--- a/Gui/python/SimplifiedMainWidget.py
+++ b/Gui/python/SimplifiedMainWidget.py
@@ -374,6 +374,7 @@ class SimplifiedMainWidget(QWidget):
         self.setupBeBoard()
         # self.setupStatusWidgets()
         self.setupUI()
+        self.RunButtonState()
 
     def updateArduinoIndicator(self):
         if self.ArduinoGroup.condensationRisk:
@@ -523,6 +524,29 @@ class SimplifiedMainWidget(QWidget):
             for key, value in self.instrument_info.items():
                 value["Value"].setPixmap(self.redledpixmap)
         logger.debug(f"{__name__} Setup led labels")
+        logger.debug(f"Instrument status: {self.instrument_status}")       
+    def RunButtonState(self):
+        """
+        Check the status of LV, HV, and FC7, and disable the Run button
+        if any of these statuses are False.
+        """
+        try:
+            # Check FC7 statuses
+            fc7_status = any(self.instrument_status.get(f"fc7_{firmwareName}", False) for firmwareName in site_settings.FC7List.keys())
+            logger.debug(f"FC7 status: {fc7_status}")
+
+            # Disable the Run button if any status is False
+            # if self.instruments is False then icicle failed to connect to LV and HV
+            if not (self.instruments and fc7_status):
+                self.RunButton.setDisabled(True)
+                logger.debug("RunButton disabled due to one or more failing statuses.")
+            else:
+                self.RunButton.setDisabled(False)
+                logger.debug("RunButton enabled. All statuses are good.")
+
+        except Exception as e:
+            logger.error(f"Error while checking instrument statuses: {e}")
+            self.RunButton.setDisabled(True)
 
     def check_icicle_devices(self) -> Optional[dict[str, int]]:
         """


### PR DESCRIPTION
## Description
If simple GUI couldn't connect to HV or LV, the Go button was still able to be pressed, making the app crash shortly after. Added a function to the simple GUI that would disable the Go button if the HV,LV,FC7 connections could not be made.

## Checklist
Before submitting this PR, please ensure the following:

- [x] I am using the **correct branches/versions** of all submodules.
- [x] I have successfully **launched the Simplified GUI**.
- [x] I have successfully **run a test in the Simplified GUI**.
- [x] I have successfully **run a test in the Expert GUI**.

## Changes Made
Added function in SimplifiedMainWidget.py to check for connections and disable/enable Go button based on connection status.

## Testing
Ran functional tests for simple and expert mode. Verified that Simple GUI Go button works for connected Fc7, LV, HV and is disabled for disconnect.

