### PR TITLE
SLDO graphs use Pin 9 as input Voltage instead of reading LV supply

### DIFF
--- a/Gui/python/SLDOScanHandler.py
+++ b/Gui/python/SLDOScanHandler.py
@@ -44,16 +44,16 @@ class SLDOCurveWorker(QThread):
         self.PIN_MAPPINGS = {
             "DEFAULT": AdcBoard.DEFAULT_PIN_MAP,
             "DOUBLE": {
-                0: 'VDDA_ROC1',
-                # 1: 'VDDA_ROC3',
+                # 0: 'VDDA_ROC1',
+                1: 'VDDA_ROC1',
                 # 2: 'VDDD_ROC2',
                 # 3: 'VDDD_ROC3',
-                4: 'VDDD_ROC1',
-                 #5: 'TP7D', #VOFS OUT
+                # 4: 'VDDD_ROC1',
+                5: 'VDDD_ROC1', #VOFS OUT
                 # 6: None,
                 # 7: 'TP8', #VOFS IN
                 # 8: None,
-                # 9: 'TP10', #VIN
+                9: 'TP10', #VIN
                 # 10: None,
                 11: "VDDA_ROC0",
                 #12: "VDDA_ROC1",
@@ -72,7 +72,7 @@ class SLDOCurveWorker(QThread):
                 # 6: None,
                 # 7: 'TP8', #VOFS IN
                 # 8: None,
-                # 9: 'TP10', #VIN
+                9: 'TP10', #VIN
                 # 10: None,
                 11: "VDDA_ROC0",
                 12: "VDDA_ROC1",
@@ -153,14 +153,21 @@ class SLDOCurveWorker(QThread):
         self.instruments.lv_off()
 
         # extract lv voltage and lv current
-        LV_Voltage_Up = [res[4] for res in data_up]
         Currents_Up = [res[5] for res in data_up]
-        LV_Voltage_Down = [res[4] for res in data_down]
         Currents_Down = [res[5] for res in data_down]
+
+        # Use the results of pin 9 as LV_Voltage_Up and LV_Voltage_Down
+        pin_9_index = 9  # Pin index for "TP10"
+        LV_Voltage_Up = [res[6][pin_9_index] for res in data_up]
+        LV_Voltage_Down = [res[6][pin_9_index] for res in data_down]
 
         for index, pin in self.PIN_MAPPINGS[
             self.moduleType.split(" ")[-1].replace("1x2", "DOUBLE").upper()
         ].items():
+        
+            if index == 9:
+                continue
+
             ADC_Voltage_Up = [res[6][index] for res in data_up]
             result_up = np.array([Currents_Up, LV_Voltage_Up, ADC_Voltage_Up])
             ADC_Voltage_Down = [res[6][index] for res in data_down]


### PR DESCRIPTION
## Description
SLDO made graphs that would compare pin voltages to the LV power supply. This PR now plots each pin with pin 9, which is the pin that tracks the input voltage. Also, pins_mapping should not be correctly set for double modules.

## Checklist
Before submitting this PR, please ensure the following:

- [X] I am using the **correct branches/versions** of all submodules.
- [X] I have successfully **launched the Simplified GUI**.
- [X] I have successfully **run a test in the Expert GUI**.

## Changes Made
Changed the LV_Voltage vars to read from pin 9. Also changed pin_mappings dict to read the correct pins. 

## Testing
Ran SLDO and uploaded to Panthera. Now all four graphs (VDDA0, VDDD0, VDDA1, VDDD1) are produced in the Result Tree and upload to Panthera correctly.