### PR TITLE
Support for Quad and 1x2 TFPX with HDI version 2

### DIFF
--- a/Gui/GUIutils/guiUtils.py
+++ b/Gui/GUIutils/guiUtils.py
@@ -45,7 +45,7 @@ from InnerTrackerTests.MonitoringSettings import (
     Monitoring_DictB,
 )
 from InnerTrackerTests.RegisterSettings import RegisterSettings, RegisterSettings_dict
-from InnerTrackerTests.FELaneConfig import FELaneConfig_DictB, FELaneConfig_DictB2
+from InnerTrackerTests.FELaneConfig import FELaneConfig_DictB
 from Gui.python.logging_config import logger
 from InnerTrackerTests.TestSequences import CompositeTests, Test_to_Ph2ACF_Map
 ##########################################################################
@@ -425,14 +425,8 @@ def GenerateXMLConfig(BeBoard, testName, outputDir, **arg):
             HWSettings_Dict = (
                 HWSettings_DictB if "CROC" in moduleType else HWSettings_DictA
             )
-            FELaneConfig_Dict = (
-                FELaneConfig_DictB2[module.getModuleType().split(" ")[0]]
-                if "CROC" in moduleType and "TFPX" in moduleType
-                else FELaneConfig_DictB[module.getModuleType().split(" ")[0]]
-                if "CROC" in moduleType
-                else None
-            )
-#####
+            FELaneConfig_Dict = FELaneConfig_DictB[registerKey]
+               
             if FELaneConfig_Dict is None:
                 logger.error(f"No FELaneConfig found for module type {module.getModuleType()}.")
             else:

--- a/Gui/GUIutils/guiUtils.py
+++ b/Gui/GUIutils/guiUtils.py
@@ -45,7 +45,7 @@ from InnerTrackerTests.MonitoringSettings import (
     Monitoring_DictB,
 )
 from InnerTrackerTests.RegisterSettings import RegisterSettings, RegisterSettings_dict
-from InnerTrackerTests.FELaneConfig import FELaneConfig_DictB
+from InnerTrackerTests.FELaneConfig import FELaneConfig_DictB, FELaneConfig_DictB2
 from Gui.python.logging_config import logger
 from InnerTrackerTests.TestSequences import CompositeTests, Test_to_Ph2ACF_Map
 ##########################################################################
@@ -426,10 +426,42 @@ def GenerateXMLConfig(BeBoard, testName, outputDir, **arg):
                 HWSettings_DictB if "CROC" in moduleType else HWSettings_DictA
             )
             FELaneConfig_Dict = (
-                FELaneConfig_DictB[module.getModuleType().split(" ")[0]]
+                FELaneConfig_DictB2[module.getModuleType().split(" ")[0]]
+                if "CROC" in moduleType and "TFPX" in moduleType
+                else FELaneConfig_DictB[module.getModuleType().split(" ")[0]]
                 if "CROC" in moduleType
                 else None
             )
+#####
+            if FELaneConfig_Dict is None:
+                logger.error(f"No FELaneConfig found for module type {module.getModuleType()}.")
+            else:
+                for chip in module.getChips().values():
+                    print("chip {0} status is {1}".format(chip.getID(), chip.getStatus()))
+                    FEChip = FE()
+                    FEChip.SetFE(
+                        chip.getID(),
+                        "1" if chip.getStatus() else "0",
+                        chip.getLane(),
+                        RxPolarities,
+                        "CMSIT_RD53_{0}_{1}_{2}.txt".format(
+                            module.getModuleName(), module.getFMCPort(), chip.getID()
+                        ),
+                    )
+
+                    if testName in FELaneConfig_Dict:
+                        FEChip.ConfigureLaneConfig(
+                            FELaneConfig_Dict[testName][int(chip.getLane())]
+                        )
+                    else:
+                        logger.warning(f"Test name {testName} not found in FELaneConfig_Dict.")
+                        if "default" in FELaneConfig_Dict:
+                            FEChip.ConfigureLaneConfig(
+                                FELaneConfig_Dict["default"][int(chip.getLane())]
+                            )
+                        else:
+                            logger.error(f"No default configuration available for test name {testName}.")
+#####
             boardtype = (
                 "RD53B" + module.getModuleVersion() if "CROC" in moduleType else "RD53A"
             )

--- a/Gui/QtGUIutils/QtApplication.py
+++ b/Gui/QtGUIutils/QtApplication.py
@@ -965,6 +965,7 @@ class QtApplication(QWidget):
         if self.multimeter:
             self.groupbox_mpaping["multimeter"] = self.multimeter_group
 
+        # only for the simplified GUI so this default should not matter right?
     def setDefault(self):
         if self.expertMode is False:
             self.HVPowerGroup.setDisabled(True)
@@ -1025,8 +1026,10 @@ class QtApplication(QWidget):
                 self.errorMessageBoxSignal.emit("Please Check Instrument Connections")
                 self.instruments = None
 
+                # arduino control here: check why this does not work. 
         if self.expertMode:
             if self.ArduinoControl.isChecked():
+                self.ArduinoGroup.setEnabled(True)
                 self.ArduinoGroup.setBaudRate(site_settings.defaultSensorBaudRate)
                 self.ArduinoGroup.frozeArduinoPanel()
 


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of the changes in this PR. -->

## Checklist
Before submitting this PR, please ensure the following:

- [ x] I am using the **correct branches/versions** of all submodules.
- [ x] I have successfully **launched the Simplified GUI**.
- [x ] I have successfully **run a test in the Simplified GUI**.
- [ x] I have successfully **run a test in the Expert GUI**.

## Related Issues
Closes issue #446

## Changes Made
Updated guiUtils and FELaneConfig to support quad and 1x2 modules in the new HDI

## Testing
tested SH0012, RH0104, SH0101 modules and they worked. 

## Additional Notes
<!-- Add any additional comments or context if needed. -->
