### PR TITLE
Added monitoring sleep time dict for test-specific sleep times

### DIFF
--- a/Configuration/XMLUtil.py
+++ b/Configuration/XMLUtil.py
@@ -10,7 +10,6 @@ from InnerTrackerTests.FELaneConfig import *
 from Gui.siteSettings import (
   Monitor_RD53A,
   Monitor_CROC,
-  Monitor_SleepTime,
 )
 #from Gui.GUIutils.settings import *
 #from Gui.python.CustomizedWidget import ModuleBox
@@ -204,7 +203,7 @@ class MonitoringModule():
       self.Enable=Monitor_RD53A
     else:
       self.Enable=Monitor_CROC
-    self.SleepTime=Monitor_SleepTime
+    self.SleepTime= "30000"
     self.MonitoringList = {}
   def SetType(self, Type):
     self.Type=Type

--- a/Gui/GUIutils/guiUtils.py
+++ b/Gui/GUIutils/guiUtils.py
@@ -43,6 +43,7 @@ from InnerTrackerTests.HWSettings import (
 from InnerTrackerTests.MonitoringSettings import (
     MonitoringListA,
     Monitoring_DictB,
+    Monitor_SleepTime,
 )
 from InnerTrackerTests.RegisterSettings import RegisterSettings, RegisterSettings_dict
 from InnerTrackerTests.FELaneConfig import FELaneConfig_DictB
@@ -513,6 +514,7 @@ def GenerateXMLConfig(BeBoard, testName, outputDir, txt_files:dict, **arg):
         MonitoringModule0.SetMonitoringList(MonitoringListA)
     else:
         if testName in Monitoring_DictB:
+            MonitoringModule0.SetSleepTime(Monitor_SleepTime[testName])
             MonitoringModule0.SetMonitoringList(Monitoring_DictB[testName])
         else:
             MonitoringModule0.SetMonitoringList({})

--- a/Gui/siteConfig.py
+++ b/Gui/siteConfig.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from MonitoringSettings import Monitor_SleepTime
 
 CONFIG_VER = 0
 
@@ -73,7 +74,6 @@ IVcurve_range = {
 ## Set this to "1" if you want the monitoring enabled.  Set it to "0" if you want it disabled. ##
 Monitor_RD53A = "1"
 Monitor_CROC = "1"
-Monitor_SleepTime = "1000"  # time in milliseconds between temperature readings
 
 SLDOScan_GADC = {
     "1x2":{
@@ -88,7 +88,7 @@ SLDOScan_GADC = {
 		"target current":7,
 		"step size":.5
 	},
-    "physics seconds": 1.5*int(Monitor_SleepTime)/1000
+    "physics seconds": 1.5*int(Monitor_SleepTime['SLDOScan_GADC'])/1000
 }
 
 forward_bias_voltage = 0.5 #positive voltage used to run a forward-reverse bias bump bond test


### PR DESCRIPTION
## Description
Added dictionary for setting monitoring times

## Checklist
Before submitting this PR, please ensure the following:

- [x] I am using the **correct branches/versions** of all submodules.
- [x] I have successfully **launched the Simplified GUI**.
- [x] I have successfully **run a test in the Simplified GUI**.
- [x] I have successfully **run a test in the Expert GUI**.

## Related Issues


## Changes Made
Now uses Monitor_SleepTime dict from InnerTrackerTests to set test-specific monitor sleep time.

## Testing
<!-- Describe how you tested your changes, including commands run, configurations used, etc. -->

## Additional Notes
<!-- Add any additional comments or context if needed. -->
