### PR TITLE
prevent duplicate Panthera upload bars

### DIFF
--- a/Gui/QtGUIutils/QtRunWindow.py
+++ b/Gui/QtGUIutils/QtRunWindow.py
@@ -359,6 +359,12 @@ class QtRunWindow(QWidget):
         self.mainLayout.removeWidget(self.MainBodyBox)
 
     def upload_to_Panthera_starter(self):
+
+        #Prevent duplicate upload progress bars
+        if hasattr(self, "UploadProgressBar") and self.UploadProgressBar is not None:
+            if self.UploadProgressBar.isVisible():
+                return
+            
         self.UploadProgressBar = QProgressBar()
         self.UploadWheel = LoadingWheel()
         self.UploadProgressBar.setFormat(f"0/{len(self.testHandler.modules)} uploaded")


### PR DESCRIPTION
prevent duplicate panthera upload progress bars by checking if one is already visible before creating another

## Description
<!-- Provide a clear and concise description of the changes in this PR. -->

## Checklist
Before submitting this PR, please ensure the following:

- [x] I am using the **correct branches/versions** of all submodules.
- [x] I have successfully **launched the Simplified GUI**.
- [x] I have successfully **run a test in the Simplified GUI**.
- [x] I have successfully **run a test in the Expert GUI**.

## Related Issues
closes issue #460 

## Changes Made
added a few lines to check if an Upload to Panthera progress bar is already visible. If yes, then no new progress bar is made if the upload button is pressed multiple times. The Upload button becomes disabled after clicked once, so Im not 100% sure this is even necessary but its there anyways. 

## Testing
Had to update the image and then I ran functional test on SH0012 twice and it looked good both times.

## Additional Notes
<!-- Add any additional comments or context if needed. -->
