### PR TITLE
Adding backward compatibility for TFPX HDIv1

### DIFF
--- a/Gui/GUIutils/settings.py
+++ b/Gui/GUIutils/settings.py
@@ -1,6 +1,7 @@
 # November 19 2021:  Edited by Matt Joyce.  Added information for Purdue database to DBNames and DBServerIP
 
 from collections import defaultdict
+import copy
 # from Gui.siteSettings import *
 # import InnerTrackerTests.TestSequences as TestSequences
 
@@ -114,13 +115,18 @@ ModuleLaneMap = {
     "TBPX RD53A Quad": {"0": "4", "1": "5", "2": "6", "3": "7"},
     "SCC": {"0": "0"},
     "CROC SCC": {"0": "15"},
-    "TFPX CROC 1x2": {"3": "12", "1": "13"},
+    "TFPX CROC 1x2": {"0": "12", "2": "13"},
     "TEPX CROC 1x2": {"0": "0", "2": "2"},
     "TBPX CROC 1x2": {"0": "0", "2": "2"},
     "TFPX CROC Quad": {"2": "12", "1": "13", "0": "14", "3": "15"},
     "TEPX CROC Quad": {"0": "15", "1": "14", "2": "13", "3": "12"},
     "TBPX CROC Quad": {"0": "0", "1": "1", "2": "2", "3": "3"},
 }
+ModuleLaneMap_Dict = {}
+ModuleLaneMap_Dict["HDIv1"] = copy.deepcopy(ModuleLaneMap)
+ModuleLaneMap_Dict["HDIv2"] = copy.deepcopy(ModuleLaneMap)
+
+ModuleLaneMap_Dict["HDIv2"]["TFPX CROC 1x2"] = {"3": "12", "1": "13"}
 
 ChipMap = {
     "TFPX CROC 1x2": {
@@ -157,7 +163,6 @@ optimizationTestMap = {
         "DAC_GDAC_R_LIN",
         "Vthreshold_LIN",
     ],
-    "thrmin": ["DAC_GDAC_M_LINDAC_GDAC_L_LINDAC_GDAC_R_LINVthreshold_LIN"],
     "threq": [
         "VCAL_HIGH",
     ],

--- a/Gui/python/CustomizedWidget.py
+++ b/Gui/python/CustomizedWidget.py
@@ -27,6 +27,7 @@ from Gui.python.Firmware import (
 )
 from Gui.GUIutils.settings import (
     ModuleLaneMap,
+    ModuleLaneMap_Dict,
     ModuleType,
 )
 # from Gui.GUIutils.FirmwareUtil import *
@@ -733,7 +734,7 @@ class BeBoardBox(QWidget):
             )  # Ignore this line, see explanation in Firmware.py
 
             # Pull VDDA/VDDD trim and chip status from the ChipBox on the StartWindow.
-            for chipID in ModuleLaneMap[module.getType()].values():
+            for chipID in ModuleLaneMap_Dict["HDIv{0}".format(module.getHDIVersion())][module.getType()].values():
                 Module.getChips()[chipID].setStatus(
                     self.ChipWidgetDict[module].getChipStatus(chipID)
                 )

--- a/Gui/python/Firmware.py
+++ b/Gui/python/Firmware.py
@@ -1,5 +1,6 @@
 from Gui.GUIutils.settings import (
     ModuleLaneMap,
+    ModuleLaneMap_Dict,
 )
 
 
@@ -124,7 +125,7 @@ class QtModule:
     def __setupChips(self):
         self.__chipDict.clear()
 
-        for LaneID, ChipID in ModuleLaneMap[self.__moduleType].items():
+        for LaneID, ChipID in ModuleLaneMap_Dict["HDIv{0}".format(self.__hdiVersion)][self.__moduleType].items():
             FEChip = QtChip(
                 chipID=ChipID, chipLane=LaneID, chipVDDA=8, chipVDDD=8, chipStatus=True
             )


### PR DESCRIPTION
## Description
Adding backward compatiblity for TFPX HDIv1 modules (specifically 1x2)

## Checklist
Before submitting this PR, please ensure the following:

- [x] I am using the **correct branches/versions** of all submodules.
- [x] I have successfully **launched the Simplified GUI**.
- [x] I have successfully **run a test in the Simplified GUI**.
- [x] I have successfully **run a test in the Expert GUI**.

## Related Issues
Fixes Issue #472 

## Changes Made
Expanded the lane map dictionary to be nested with the HDI version as the key.

## Testing
Ran functional tests for RH0051, RH0014, and RH0104 in both expert and simplified GUI versions.

## Additional Notes
<!-- Add any additional comments or context if needed. -->
