### PR TITLE
Update docker ci

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -18,9 +18,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-          with:
-            submodules: recursive
-            fetch-depth: 0  # Important! Needed to preserve .git directory
+        with:
+          submodules: recursive
+          fetch-depth: 0  # Important! Needed to preserve .git directory
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -47,6 +47,6 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
-
           tags: osupixels/ph2_acf_gui_dev:${{ env.BRANCH_NAME }}
-
+          build-args: |
+            BUILDKIT_CONTEXT_KEEP_GIT_DIR=true

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -18,7 +18,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-
+          with:
+            submodules: recursive
+            fetch-depth: 0  # Important! Needed to preserve .git directory
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ FROM $FROM_IMAGE AS base
 
 SHELL ["/bin/bash", "-c"]
 
+# This ensures that the submodules are treated as git repositories
+COPY .git .git 
+
 #Setting up all of the environment variables that the GUI will use.
 #An ARG is only in the scope of the build that immediately follows, so you have to re-do this for each usage.
 ARG GIT_REF=Dev

--- a/prepare_Ph2ACF.sh
+++ b/prepare_Ph2ACF.sh
@@ -7,6 +7,9 @@ export PH2ACF_VERSION=$(git describe --tags)
 cd ${GUI_dir}
 source symlinks.sh
 
+# For some reason we get "dubious ownership" issues with felis
+git config --global --add safe.directory /home/cmsTkUser/Ph2_ACF_GUI/felis
+
 export PH2_ACF_GUI_VERSION=$(git describe --tags)
 export FELIS_VERSION=$(git -C felis describe --tags)
 export ICICLE_VERSION=$(git -C icicle describe --tags)

--- a/prepare_Ph2ACF.sh
+++ b/prepare_Ph2ACF.sh
@@ -7,6 +7,10 @@ export PH2ACF_VERSION=$(git describe --tags)
 cd ${GUI_dir}
 source symlinks.sh
 
+export PH2_ACF_GUI_VERSION=$(git describe --tags)
+export FELIS_VERSION=$(git -C felis describe --tags)
+export ICICLE_VERSION=$(git -C icicle describe --tags)
+
 cd ${GUI_dir}/Gui/python
 
 


### PR DESCRIPTION
## Description
This docker image fixes an issue where the submodules weren't being recognized as git repositories within the docker image. This PR also adds version tracking for all submodules with tags. 
## Checklist
Before submitting this PR, please ensure the following:

- [ x] I am using the **correct branches/versions** of all submodules.
- [x ] I have successfully **launched the Simplified GUI**.
- [x ] I have successfully **run a test in the Simplified GUI**.
- [ x] I have successfully **run a test in the Expert GUI**.

## Related Issues
Closes issue #484 

