### PR TITLE
QoL update to using the arduino monitoring

### DIFF
--- a/Gui/QtGUIutils/QtApplication.py
+++ b/Gui/QtGUIutils/QtApplication.py
@@ -996,12 +996,11 @@ class QtApplication(QWidget):
                 self.errorMessageBoxSignal.emit("Please Check Instrument Connections")
                 self.instruments = None
 
-                # arduino control here: check why this does not work. 
         if self.expertMode:
             if self.ArduinoControl.isChecked():
                 self.ArduinoGroup.setEnabled(True)
                 self.ArduinoGroup.setBaudRate(site_settings.defaultSensorBaudRate)
-                self.ArduinoGroup.frozeArduinoPanel()
+                self.ArduinoGroup.setArduinoPanel()
 
     def disable_instrument_widgets(self):
         """
@@ -1178,6 +1177,7 @@ class QtApplication(QWidget):
         if self.ArduinoControl.isChecked():
             self.ArduinoGroup.enable()
         else:
+            self.ArduinoGroup.releaseArduinoPanel()
             self.ArduinoGroup.disable()
 
     def checkFirmware(self):

--- a/Gui/python/ArduinoWidget.py
+++ b/Gui/python/ArduinoWidget.py
@@ -167,6 +167,9 @@ class ArduinoWidget(QWidget):
             logger.error(f"Unable to use Arduino: {err}")
             self.ArduinoGoodStatus = False
 
+    def setArduinoPanel(self):
+        self.UseArduino.setDisabled(False)
+
     def releaseArduinoPanel(self):
         self.serial.close()
         self.ArduinoCombo.setDisabled(False)
@@ -241,7 +244,11 @@ class ArduinoWidget(QWidget):
             deviceName, baudRate=baudMap[baudRate], readyRead=self.receive
         )
         self.serial.open(QIODevice.ReadOnly)
-        print(self.serial.isOpen())
+        print(f"Serial status: {self.serial.isOpen()}")
+
+        if not self.serial.isOpen():
+            self.ArduinoMeasureValue.setStyleSheet("QLabel {color : red}")
+            self.ArduinoMeasureValue.setText("The Arduino could not be connected to.")
 
     def disable(self):
         self.ArduinoGroup.setDisabled(True)


### PR DESCRIPTION
## Description
Made slight changes to the "Use arduino monitoring" checkbox and the "connect all devices" button functionality so that the arduino can be selected either before or after pressing "connect all devices". If the user forgets to press the Arduino's "use" button before pressing "connect all devices" they can now press "use" without having to press the arduino's "release" button first. 

Also fixes a slight bug with de-selecting the "use arduino monitoring" checkbox not releasing the arduino. 

## Checklist
Before submitting this PR, please ensure the following:

- [x] I am using the **correct branches/versions** of all submodules.
- [x] I have successfully **launched the Simplified GUI**.
- [x] I have successfully **run a test in the Simplified GUI**.
- [x] I have successfully **run a test in the Expert GUI**.

## Related Issues
Closes issue #447 

## Changes Made
When "connect all devices" is selected, a new function "setArduinoPanel" is called rather than "frozeArduinoPanel" which was causing "Use" to be disabled. for now, setArduinoPanel simply enables the "use" button, but can be changed in the future to do more if needed. 

Also, switchArduinoPanel now calls releaseArduinoPanel if "Use arduino monitoring" is not selected to fix a bug where deselecting the checkbox would keep the arduino active while also disabling the release button, so the user would have to re-select the checkbox, then release, and then unselect the checkbox. 

## Testing
Opened Simple GUI, then opened expert GUI, selected and unselected the "Use", "release", "connect all devices" and "Use arduino monitoring" buttons a whole lot and made sure I got the correct responses from the software, then ran Functional Test to make sure it still worked fine. 

## Additional Notes
<!-- Add any additional comments or context if needed. -->

