### PR TITLE
NTCBETA and RNTCAT25C values are different dependent on HDI version

### DIFF
--- a/Gui/GUIutils/guiUtils.py
+++ b/Gui/GUIutils/guiUtils.py
@@ -11,7 +11,7 @@ import sys
 import os
 from datetime import datetime, timedelta
 from subprocess import Popen, PIPE
-from InnerTrackerTests.FESettings import FESettingsB_dict, FESettingsB
+from InnerTrackerTests.FESettings import FESettingsB
 
 from Gui.GUIutils.settings import (
     updatedGlobalValue,
@@ -419,7 +419,7 @@ def GenerateXMLConfig(BeBoard, testName, outputDir, txt_files:dict, **arg):
 
 
             FESettings_Dict = (
-                {test_key: FESettingsB_dict.get(registerKey, FESettingsB) for test_key in HWSettings_DictB}
+                {test_key: FESettings_DictB.get(registerKey, FESettingsB) for test_key in HWSettings_DictB}
                 if "CROC" in moduleType else FESettings_DictA
             ) 
             globalSettings_Dict = (

--- a/Gui/GUIutils/guiUtils.py
+++ b/Gui/GUIutils/guiUtils.py
@@ -11,6 +11,7 @@ import sys
 import os
 from datetime import datetime, timedelta
 from subprocess import Popen, PIPE
+from InnerTrackerTests.FESettings import FESettingsB_dict, FESettingsB
 
 from Gui.GUIutils.settings import (
     updatedGlobalValue,
@@ -416,10 +417,11 @@ def GenerateXMLConfig(BeBoard, testName, outputDir, txt_files:dict, **arg):
             )
             #revPolarity = bool(int(RxPolarities))
 
-            
+
             FESettings_Dict = (
-                FESettings_DictB if "CROC" in moduleType else FESettings_DictA
-            )
+                {test_key: FESettingsB_dict.get(registerKey, FESettingsB) for test_key in HWSettings_DictB}
+                if "CROC" in moduleType else FESettings_DictA
+            ) 
             globalSettings_Dict = (
                 globalSettings_DictB if "CROC" in moduleType else globalSettings_DictA
             )
@@ -443,6 +445,7 @@ def GenerateXMLConfig(BeBoard, testName, outputDir, txt_files:dict, **arg):
                             module.getModuleName(), module.getFMCPort(), chip.getID()
                         ),
                     )
+                    FEChip.ConfigureFE(FESettings_Dict[testName])
 
                     if testName in FELaneConfig_Dict:
                         FEChip.ConfigureLaneConfig(

--- a/Gui/GUIutils/guiUtils.py
+++ b/Gui/GUIutils/guiUtils.py
@@ -11,7 +11,7 @@ import sys
 import os
 from datetime import datetime, timedelta
 from subprocess import Popen, PIPE
-from InnerTrackerTests.FESettings import FESettingsB
+from InnerTrackerTests.FESettings import FESettingsB_dict
 
 from Gui.GUIutils.settings import (
     updatedGlobalValue,
@@ -419,7 +419,7 @@ def GenerateXMLConfig(BeBoard, testName, outputDir, txt_files:dict, **arg):
 
 
             FESettings_Dict = (
-                {test_key: FESettings_DictB.get(registerKey, FESettingsB) for test_key in HWSettings_DictB}
+                {test_key: FESettings_DictB.get(registerKey, FESettingsB_dict) for test_key in HWSettings_DictB}
                 if "CROC" in moduleType else FESettings_DictA
             ) 
             globalSettings_Dict = (
@@ -445,7 +445,7 @@ def GenerateXMLConfig(BeBoard, testName, outputDir, txt_files:dict, **arg):
                             module.getModuleName(), module.getFMCPort(), chip.getID()
                         ),
                     )
-                    FEChip.ConfigureFE(FESettings_Dict[testName])
+                    FEChip.ConfigureFE(FESettings_Dict[testName][registerKey])
 
                     if testName in FELaneConfig_Dict:
                         FEChip.ConfigureLaneConfig(


### PR DESCRIPTION
## Description
guiUtils now uses either FESettingsB_HDIv1 or FESettingsB_HDIv2 depending on the hdi version of the chip that is used. these are found in FESettings.py (Which will have to get pushed separately as it is in innerTrackerTests) and use different NTCBETA and RNTCAT25C values. 

## Checklist
Before submitting this PR, please ensure the following:

- [x] I am using the **correct branches/versions** of all submodules.
- [x] I have successfully **launched the Simplified GUI**.
- [x] I have successfully **run a test in the Simplified GUI**.
- [x] I have successfully **run a test in the Expert GUI**.

## Changes Made
guiUtils uses either FESettingsB_HDIv1 or FESettingsB_HDIv2 depending on the HDI version of the chip. (or FESettings_DictA if the module type is not CROC). 

Then, in FESettings.py, the v1 and v2 dictionaries have different values for RNTCAT25C (v1 = 10000, v2 = 1500 )and NTCBETA (v1 = 3380, v2 = 3500). 

## Testing
ran tests with SH0012 (hdi version 1) and RH0104 (hdi version 2) and checked the xml files to ensure that NTCBETA and RNTCAT25C were correct for the respective hdi version. also opened simple gui to make sure it worked.

