### PR TITLE
GUI Permission Error Fix Update

### DIFF
--- a/run_Docker.sh
+++ b/run_Docker.sh
@@ -49,14 +49,9 @@ echo $mydevices | xargs
 if [[ $mode == "dev" ]] 
 then
 	# Fix ownership of ./data if it exists (for dev mode)
-    if [ -d ./data ]; then
-    CURRENT_UID=$(stat -c "%u" ./data)
-    if [ "$CURRENT_UID" != "$USER_UID" ]; then
-        echo "⚠️  ./data has incorrect ownership."
-        echo "👉 Please run: sudo chown -R $USER_UID:$USER_UID ./data"
-    else
-        echo "✅ ./data already has correct ownership"
-    fi
+   if [ -d ./data ]; then
+    echo "🔧 Updating ownership of ./data to match current user..."
+    docker run --rm -v "$(pwd)/data:/mnt/data" alpine chown -R $(id -u):$(id -g) /mnt/data
 else
     echo "⚠️  ./data directory does not exist. Skipping permission fix."
 fi

--- a/run_Docker.sh
+++ b/run_Docker.sh
@@ -4,6 +4,7 @@ CONFIG_VER=2
 
 bash ./check_configuration_files.sh run_Docker.sh Gui/siteConfig.py
 
+
 SOCK=/tmp/.X11-unix; XAUTH=/tmp/.docker.xauth; xauth nlist $DISPLAY | sed -e 's/^..../ffff/' | xauth -f $XAUTH nmerge -; chmod 777 $XAUTH;
 
 ######### Specify the docker image to use #################
@@ -15,21 +16,6 @@ IMAGE_NAME="non_root_1"
 
 mode=$1
 
-# --- 🔧 AUTO-FIX PERMISSIONS FOR /data ---
-echo "🔎 Detecting UID of cmsTkUser inside Docker image..."
-USER_UID=$(docker run --rm --entrypoint bash $IMAGE_NAME -c "id -u cmsTkUser" 2>/dev/null)
-
-if [ -z "$USER_UID" ]; then
-    echo "❌ Could not determine UID of cmsTkUser. Aborting permission fix."
-else
-    echo "✅ UID of cmsTkUser: $USER_UID"
-    if [ -d ./data ]; then
-        echo "🔧 Updating ownership of ./data to UID:$USER_UID using Alpine container"
-        docker run --rm -v "$(pwd)/data:/mnt/data" alpine chown -R $USER_UID:$USER_UID /mnt/data
-    else
-        echo "⚠️  ./data directory does not exist. Skipping permission fix."
-    fi
-fi
 
 ## Finding the USB ports to use with the GUI#############
 mydevices=""
@@ -63,18 +49,28 @@ mydevices=$(echo $mydevices | xargs)
 echo $mydevices | xargs
 ################################################################################################
 
-if [[ $mode == "dev" ]] 
-then
-	# Fix ownership of ./data if it exists (for dev mode)
-   if [ -d ./data ]; then
-    echo "🔧 Updating ownership of ./data to match current user..."
-    docker run --rm -v "$(pwd)/data:/mnt/data" alpine chown -R $(id -u):$(id -g) /mnt/data
+
+echo "🔎 Detecting UID of cmsTkUser inside Docker image..."
+USER_UID=$(docker run --rm --entrypoint bash $IMAGE_NAME -c "id -u cmsTkUser" 2>/dev/null)
+
+if [ -z "$USER_UID" ]; then
+    echo "❌ Could not determine UID of cmsTkUser. Aborting permission fix."
 else
-    echo "⚠️  ./data directory does not exist. Skipping permission fix."
+    echo "✅ UID of cmsTkUser: $USER_UID"
+    if [ -d ./data ]; then
+        echo "🔧 Updating ownership of ./data to UID:$USER_UID using Alpine container"
+        docker run --rm -v "$(pwd)/data:/mnt/data" alpine chown -R $USER_UID:$USER_UID /mnt/data
+    else
+        echo "⚠️  ./data directory does not exist. Skipping permission fix."
+    fi
 fi
 
 
-    echo "running as $mode"
+
+
+if [[ $mode == "dev" ]] 
+then
+	echo "running as $mode"
     docker run --detach-keys='ctrl-e,e' --rm -ti $mydevices -v ${PWD}:${PWD}\
 		-v ${PWD}/icicle/icicle:/home/cmsTkUser/Ph2_ACF_GUI/icicle/icicle:ro\
 		-v ${PWD}/Gui/siteConfig.py:/home/cmsTkUser/Ph2_ACF_GUI/Gui/siteSettings.py\

--- a/run_Docker.sh
+++ b/run_Docker.sh
@@ -2,12 +2,13 @@
 # DO NOT EDIT THIS BY HAND!!!
 CONFIG_VER=2
 
-bash check_configuration_files.sh run_Docker.sh Gui/siteConfig.py
+bash ./check_configuration_files.sh run_Docker.sh Gui/siteConfig.py
 
 SOCK=/tmp/.X11-unix; XAUTH=/tmp/.docker.xauth; xauth nlist $DISPLAY | sed -e 's/^..../ffff/' | xauth -f $XAUTH nmerge -; chmod 777 $XAUTH;
 
 ######### Specify the docker image to use #################
-IMAGE_NAME="osupixels/ph2_acf_gui_dev:v2-2-3-prerelease-"
+IMAGE_NAME="non_root_1"
+#IMAGE_NAME="osupixels/ph2_acf_gui_dev:v2-2-3-prerelease-"
 #IMAGE_NAME="majoyce2/ph2_acf_gui_purdue:latest"
 #IMAGE_NAME="majoyce2/ph2_acf_gui_user:latest"
 #IMAGE_NAME="local/testimagemay29user"
@@ -65,7 +66,7 @@ then
 		-v ${PWD}/symlinks.sh:/home/cmsTkUser/Ph2_ACF_GUI/symlinks.sh/\
 		-v ${PWD}/Gui/jsonFiles/:/home/cmsTkUser/Ph2_ACF_GUI/Gui/jsonFiles/\
 		-w /home/cmsTkUser/Ph2_ACF_GUI -e DISPLAY=$DISPLAY\
-		--volume="$HOME/.Xauthority:/root/.Xauthority:rw" -u root --net host --entrypoint /bin/bash $IMAGE_NAME
+		--volume="$HOME/.Xauthority:/root/.Xauthority:rw" --net host --entrypoint /bin/bash $IMAGE_NAME
 
 else
     echo "running as user"
@@ -101,6 +102,26 @@ To install on Alma Linux please run:\e[0m
     		echo "Image pull canceled."
   		fi
 	fi
+
+
+# --- 🔧 AUTO-FIX PERMISSIONS FOR /data ---
+echo "🔎 Detecting UID of cmsTkUser inside Docker image..."
+USER_UID=$(docker run --rm --entrypoint bash $IMAGE_NAME -c "id -u cmsTkUser" 2>/dev/null)
+
+if [ -z "$USER_UID" ]; then
+    echo "❌ Could not determine UID of cmsTkUser. Aborting permission fix."
+else
+    echo "✅ UID of cmsTkUser: $USER_UID"
+    if [ -d ./data ]; then
+        echo "🔧 Updating ownership of ./data to UID:$USER_UID"
+        sudo chown -R $USER_UID:$USER_UID ./data
+    else
+        echo "⚠️  ./data directory does not exist. Skipping permission fix."
+    fi
+fi
+
+
+
     docker run --detach-keys='ctrl-e,e' --rm -ti $mydevices\
 		-v ${PWD}/Gui/siteConfig.py:/home/cmsTkUser/Ph2_ACF_GUI/Gui/siteSettings.py\
 		-v ${PWD}/Ph2_ACF/test:/home/cmsTkUser/Ph2_ACF_GUI/Ph2_ACF/test\

--- a/run_Docker.sh
+++ b/run_Docker.sh
@@ -50,10 +50,18 @@ if [[ $mode == "dev" ]]
 then
 	# Fix ownership of ./data if it exists (for dev mode)
     if [ -d ./data ]; then
-        echo "🔧 Fixing ./data ownership for dev mode..."
-        sudo chown -R 1000:1000 ./data
+    CURRENT_UID=$(stat -c "%u" ./data)
+    if [ "$CURRENT_UID" != "$USER_UID" ]; then
+        echo "⚠️  ./data has incorrect ownership."
+        echo "👉 Please run: sudo chown -R $USER_UID:$USER_UID ./data"
+    else
+        echo "✅ ./data already has correct ownership"
     fi
-	
+else
+    echo "⚠️  ./data directory does not exist. Skipping permission fix."
+fi
+
+
     echo "running as $mode"
     docker run --detach-keys='ctrl-e,e' --rm -ti $mydevices -v ${PWD}:${PWD}\
 		-v ${PWD}/icicle/icicle:/home/cmsTkUser/Ph2_ACF_GUI/icicle/icicle:ro\

--- a/run_Docker.sh
+++ b/run_Docker.sh
@@ -49,24 +49,26 @@ mydevices=$(echo $mydevices | xargs)
 echo $mydevices | xargs
 ################################################################################################
 
+# --- Ensure ./data exists ---
+if [ ! -d "./data" ]; then
+    echo " ./data directory does not exist. Creating it..."
+    mkdir ./data
+fi
 
-echo "🔎 Detecting UID of cmsTkUser inside Docker image..."
+echo "Detecting UID of cmsTkUser inside Docker image..."
 USER_UID=$(docker run --rm --entrypoint bash $IMAGE_NAME -c "id -u cmsTkUser" 2>/dev/null)
 
 if [ -z "$USER_UID" ]; then
-    echo "❌ Could not determine UID of cmsTkUser. Aborting permission fix."
+    echo "Could not determine UID of cmsTkUser. Aborting permission fix."
 else
-    echo "✅ UID of cmsTkUser: $USER_UID"
+    echo "UID of cmsTkUser: $USER_UID"
     if [ -d ./data ]; then
-        echo "🔧 Updating ownership of ./data to UID:$USER_UID using Alpine container"
+        echo "Updating ownership of ./data to UID:$USER_UID using Alpine container"
         docker run --rm -v "$(pwd)/data:/mnt/data" alpine chown -R $USER_UID:$USER_UID /mnt/data
     else
-        echo "⚠️  ./data directory does not exist. Skipping permission fix."
+        echo "./data directory does not exist. Skipping permission fix."
     fi
 fi
-
-
-
 
 if [[ $mode == "dev" ]] 
 then
@@ -124,25 +126,6 @@ To install on Alma Linux please run:\e[0m
     		echo "Image pull canceled."
   		fi
 	fi
-
-
-# --- 🔧 AUTO-FIX PERMISSIONS FOR /data ---
-echo "🔎 Detecting UID of cmsTkUser inside Docker image..."
-USER_UID=$(docker run --rm --entrypoint bash $IMAGE_NAME -c "id -u cmsTkUser" 2>/dev/null)
-
-if [ -z "$USER_UID" ]; then
-    echo "❌ Could not determine UID of cmsTkUser. Aborting permission fix."
-else
-    echo "✅ UID of cmsTkUser: $USER_UID"
-    if [ -d ./data ]; then
-        echo "🔧 Updating ownership of ./data to UID:$USER_UID"
-        sudo chown -R $USER_UID:$USER_UID ./data
-    else
-        echo "⚠️  ./data directory does not exist. Skipping permission fix."
-    fi
-fi
-
-
 
     docker run --detach-keys='ctrl-e,e' --rm -ti $mydevices\
 		-v ${PWD}/Gui/siteConfig.py:/home/cmsTkUser/Ph2_ACF_GUI/Gui/siteSettings.py\

--- a/run_Docker.sh
+++ b/run_Docker.sh
@@ -8,8 +8,7 @@ bash ./check_configuration_files.sh run_Docker.sh Gui/siteConfig.py
 SOCK=/tmp/.X11-unix; XAUTH=/tmp/.docker.xauth; xauth nlist $DISPLAY | sed -e 's/^..../ffff/' | xauth -f $XAUTH nmerge -; chmod 777 $XAUTH;
 
 ######### Specify the docker image to use #################
-IMAGE_NAME="non_root_1"
-#IMAGE_NAME="osupixels/ph2_acf_gui_dev:v2-2-3-prerelease-"
+IMAGE_NAME="osupixels/ph2_acf_gui_dev:v2-2-3-prerelease-"
 #IMAGE_NAME="majoyce2/ph2_acf_gui_purdue:latest"
 #IMAGE_NAME="majoyce2/ph2_acf_gui_user:latest"
 #IMAGE_NAME="local/testimagemay29user"
@@ -63,8 +62,8 @@ if [ -z "$USER_UID" ]; then
 else
     echo "UID of cmsTkUser: $USER_UID"
     if [ -d ./data ]; then
-        echo "Updating ownership of ./data to UID:$USER_UID using Alpine container"
-        docker run --rm -v "$(pwd)/data:/mnt/data" alpine chown -R $USER_UID:$USER_UID /mnt/data
+        echo "Updating ownership of ./data to UID:$USER_UID"
+        chown -R $USER_UID: ./data
     else
         echo "./data directory does not exist. Skipping permission fix."
     fi

--- a/run_Docker.sh
+++ b/run_Docker.sh
@@ -14,6 +14,23 @@ IMAGE_NAME="non_root_1"
 #IMAGE_NAME="local/testimagemay29user"
 
 mode=$1
+
+# --- 🔧 AUTO-FIX PERMISSIONS FOR /data ---
+echo "🔎 Detecting UID of cmsTkUser inside Docker image..."
+USER_UID=$(docker run --rm --entrypoint bash $IMAGE_NAME -c "id -u cmsTkUser" 2>/dev/null)
+
+if [ -z "$USER_UID" ]; then
+    echo "❌ Could not determine UID of cmsTkUser. Aborting permission fix."
+else
+    echo "✅ UID of cmsTkUser: $USER_UID"
+    if [ -d ./data ]; then
+        echo "🔧 Updating ownership of ./data to UID:$USER_UID using Alpine container"
+        docker run --rm -v "$(pwd)/data:/mnt/data" alpine chown -R $USER_UID:$USER_UID /mnt/data
+    else
+        echo "⚠️  ./data directory does not exist. Skipping permission fix."
+    fi
+fi
+
 ## Finding the USB ports to use with the GUI#############
 mydevices=""
 target="tty"

--- a/run_Docker.sh
+++ b/run_Docker.sh
@@ -48,6 +48,12 @@ echo $mydevices | xargs
 
 if [[ $mode == "dev" ]] 
 then
+	# Fix ownership of ./data if it exists (for dev mode)
+    if [ -d ./data ]; then
+        echo "🔧 Fixing ./data ownership for dev mode..."
+        sudo chown -R 1000:1000 ./data
+    fi
+	
     echo "running as $mode"
     docker run --detach-keys='ctrl-e,e' --rm -ti $mydevices -v ${PWD}:${PWD}\
 		-v ${PWD}/icicle/icicle:/home/cmsTkUser/Ph2_ACF_GUI/icicle/icicle:ro\


### PR DESCRIPTION
## Description
The changes ensure that ./data directory is automatically created when starting the container and applies the correct permissions immediately.

## Checklist
Before submitting this PR, please ensure the following:

- [x] I am using the **correct branches/versions** of all submodules.
- [x] I have successfully **launched the Simplified GUI**.
- [x] I have successfully **run a test in the Simplified GUI**.
- [x] I have successfully **run a test in the Expert GUI**.

## Related Issues
Fixes the permission issue that required 2 runs of run.Docker.sh for ./data permissions to be correctly set

## Changes Made
modified run_Docker.sh to auto create ./data if missing to ensure ./data ownership is fixed on the first run.
