### PR TITLE
Crosstalk indexing bug

### DIFF
--- a/Gui/python/TestHandler.py
+++ b/Gui/python/TestHandler.py
@@ -469,7 +469,10 @@ class TestHandler(QObject):
             self.output_dir, self.input_dir = self.config_output_dir(testName)
             self.currentTest = testName
 
-            EnableReRun = self.onFinalTest(self.testIndexTracker + 1)
+            if "CrossTalk" in testName:
+                EnableReRun = self.onFinalTest(self.testIndexTracker)
+            else:
+                EnableReRun = self.onFinalTest(self.testIndexTracker + 1)
             self.stepFinished.emit(EnableReRun)
 
             if self.master.expertMode:
@@ -1286,8 +1289,13 @@ created by Ph2_ACF is empty."
         # validate the results
         self.validateTest()
         
-        self.testIndexTracker += 1
-        self.testsAttempted += 1
+        if (
+            "IVCurve" not in self.currentTest
+            and "SLDOScan" not in self.currentTest
+            and "CrossTalk" not in self.currentTest
+        ):
+            self.testIndexTracker += 1
+            self.testsAttempted += 1
 
 
 
@@ -1335,7 +1343,7 @@ created by Ph2_ACF is empty."
                                     "hybridID": hybridID,
                                     "module": module,
                                 }
-
+                                index -= 1
                                 self.felis.set_result(
                                     self.BBanalysis_root_files,
                                     module_data["module"].getModuleName(),


### PR DESCRIPTION
## Description
Made sure that testIndexTracker doesn't increment more than it needs to for certain tests. Tried finding where CrossTalk was indexing twice but I was unable to locate the source of the issue so gave up and simply added a line to decrement index when crosstalk was the final test in a sequence and now it uses the right number. Its not perfect but it works.  

## Checklist
Before submitting this PR, please ensure the following:

- [x] I am using the **correct branches/versions** of all submodules.
- [x] I have successfully **launched the Simplified GUI**.
- [x] I have successfully **run a test in the Simplified GUI**.
- [x] I have successfully **run a test in the Expert GUI**.



## Changes Made
index number gets decremented by 1 whenever Crosstalk is the last test in the sequence and gets incrememnted twice, so now overall it just increments by 1 like it should.

## Testing
ran fullPerformance development test, and saw in the data files that the tests are properly indexed (00_pixelAlive, 01..., 02... 03_crosstalk)

## Additional Notes
Still not sure why crosstalk was incrementing twice in the first place.
