### PR TITLE
Split and merge

### DIFF
--- a/Gui/QtGUIutils/QtMatplotlibUtils.py
+++ b/Gui/QtGUIutils/QtMatplotlibUtils.py
@@ -138,9 +138,9 @@ class RunStatusCanvas(FigureCanvas):
             except KeyError:
                 self.test_list = CompositeTests_Modules["Default"][self.info[1]]
 
-            for i in range(len(test_list)):
+            for i in range(len(self.test_list)):
                 self.xticks.append(
-                    Test_to_Ph2ACF_Map[test_list[i]]
+                    Test_to_Ph2ACF_Map[self.test_list[i]]
                 )
         if isSingleTest(self.parent.info[1]):
             self.xticks.append(Test_to_Ph2ACF_Map[self.parent.info[1]])

--- a/Gui/QtGUIutils/QtMatplotlibUtils.py
+++ b/Gui/QtGUIutils/QtMatplotlibUtils.py
@@ -18,7 +18,7 @@ from Gui.GUIutils.guiUtils import (
     isCompositeTest,
     isSingleTest,
 )
-from InnerTrackerTests.TestSequences import CompositeTests, Test_to_Ph2ACF_Map
+from InnerTrackerTests.TestSequences import CompositeTests_Modules, Test_to_Ph2ACF_Map
 
 
 class ScanCanvas(FigureCanvas):
@@ -133,9 +133,14 @@ class RunStatusCanvas(FigureCanvas):
         self.xticks = [""]
 
         if isCompositeTest(self.parent.info[1]):
-            for i in range(len(CompositeTests[self.parent.info[1]])):
+            try:            
+                self.test_list = CompositeTests_Modules[self.parent.testHandler.registerKey][self.info[1]]
+            except KeyError:
+                self.test_list = CompositeTests_Modules["Default"][self.info[1]]
+
+            for i in range(len(test_list)):
                 self.xticks.append(
-                    Test_to_Ph2ACF_Map[CompositeTests[self.parent.info[1]][i]]
+                    Test_to_Ph2ACF_Map[test_list[i]]
                 )
         if isSingleTest(self.parent.info[1]):
             self.xticks.append(Test_to_Ph2ACF_Map[self.parent.info[1]])
@@ -156,7 +161,7 @@ class RunStatusCanvas(FigureCanvas):
     def compute_initial_figure(self):
         self.axes.cla()
         if isCompositeTest(self.parent.info[1]):
-            xList = [x for x in range(1, 1 + len(CompositeTests[self.parent.info[1]]))]
+            xList = [x for x in range(1, 1 + len(self.test_list))]
         if isSingleTest(self.parent.info[1]):
             xList = [x for x in range(1, 2)]
 
@@ -208,9 +213,9 @@ class RunStatusCanvas(FigureCanvas):
     def renew(self):
         self.xticks = [""]
         if isCompositeTest(self.parent.info[1]):
-            for i in range(len(CompositeTests[self.parent.info[1]])):
+            for i in range(len(CompositeTests_Modules[self.parent.testHandler.registerKey][self.parent.info[1]])):
                 self.xticks.append(
-                    Test_to_Ph2ACF_Map[CompositeTests[self.parent.info[1]][i]]
+                    Test_to_Ph2ACF_Map[CompositeTests_Modules[self.parent.testHandler.registerKey][self.parent.info[1]][i]]
                 )
         if isSingleTest(self.parent.info[1]):
             self.xticks.append(Test_to_Ph2ACF_Map[self.parent.info[1]])

--- a/Gui/QtGUIutils/QtRunWindow.py
+++ b/Gui/QtGUIutils/QtRunWindow.py
@@ -33,7 +33,7 @@ from Gui.QtGUIutils.QtCustomizeWindow import QtCustomizeWindow
 from Gui.python.ResultTreeWidget import ResultTreeWidget
 from Gui.python.TestHandler import TestHandler
 from Gui.python.logging_config import logger
-from InnerTrackerTests.TestSequences import CompositeTests
+from InnerTrackerTests.TestSequences import CompositeTests_Modules
 
 
 class QtRunWindow(QWidget):
@@ -263,7 +263,7 @@ class QtRunWindow(QWidget):
 
         OutputLayout = QGridLayout()
         self.ResultWidget = ResultTreeWidget(
-            self.info, self.DisplayW, self.DisplayH, self.master, self.firmware
+            self.info, self.DisplayW, self.DisplayH, self.master, self.firmware, self.testHandler.registerKey
         )
         OutputLayout.addWidget(self.ResultWidget, 0, 0, 1, 1)
         OutputBox.setLayout(OutputLayout)
@@ -526,8 +526,13 @@ class QtRunWindow(QWidget):
             isReRun = True
             self.grades = []
             if isCompositeTest(self.info):
+                try:            
+                    test_list = CompositeTests_Modules[self.testHandler.registerKey][self.info]
+                except KeyError:
+                    test_list = CompositeTests_Modules["Default"][self.info]
+
                 for fw_index in range(len(self.firmware)):
-                    for index in range(len(CompositeTests[self.info])):
+                    for index in range(len(test_list)):
                         self.ResultWidget.ProgressBars[fw_index][index].setValue(0)
                         self.ResultWidget.runtimes[fw_index][index].setText("")
             else:

--- a/Gui/python/ResultTreeWidget.py
+++ b/Gui/python/ResultTreeWidget.py
@@ -24,11 +24,11 @@ from Gui.python.ROOTInterface import (
 )
 from Gui.QtGUIutils.QtTCanvasWidget import QtTCanvasWidget
 from Gui.python.logging_config import logger
-from InnerTrackerTests.TestSequences import CompositeTests
+from InnerTrackerTests.TestSequences import CompositeTests_Modules
 
 
 class ResultTreeWidget(QWidget):
-    def __init__(self, info, width, height, master, firmware):
+    def __init__(self, info, width, height, master, firmware, registerKey):
         super(ResultTreeWidget, self).__init__()
         self.master = master
         self.firmware = firmware
@@ -38,6 +38,7 @@ class ResultTreeWidget(QWidget):
         self.IVFileList = []
         self.SLDOFileList = []
         self.info = info
+        self.registerKey = registerKey
 
         self.ProgressBarLists = [[] for _ in firmware]
         self.ProgressBars = [{} for _ in firmware]
@@ -59,8 +60,13 @@ class ResultTreeWidget(QWidget):
     def initializeProgressBar(self):
         for fw_index, _ in enumerate(self.firmware):
             if isCompositeTest(self.info):
-                self.ProgressBarLists[fw_index] = CompositeTests[self.info]
-                self.runtimeLists[fw_index] = CompositeTests[self.info]
+                try:            
+                    test_list = CompositeTests_Modules[self.registerKey][self.info] 
+                except KeyError:
+                    test_list = CompositeTests_Modules["Default"][self.info]
+
+                self.ProgressBarLists[fw_index] = test_list
+                self.runtimeLists[fw_index] = test_list
             else:
                 self.ProgressBarLists[fw_index] = [self.info]
                 self.runtimeLists[fw_index] = [self.info]

--- a/Gui/python/TestHandler.py
+++ b/Gui/python/TestHandler.py
@@ -54,7 +54,7 @@ from Gui.python.IVCurveHandler import IVCurveHandler
 from Gui.python.SLDOScanHandler import SLDOCurveHandler
 import Gui.siteSettings as site_settings
 from Gui.python.logging_config import logger
-from InnerTrackerTests.TestSequences import CompositeTests, Test_to_Ph2ACF_Map
+from InnerTrackerTests.TestSequences import CompositeTests_Modules, Test_to_Ph2ACF_Map
 
 
 class TestHandler(QObject):
@@ -90,8 +90,6 @@ class TestHandler(QObject):
 
         self.modules = [module for beboard in self.firmware for module in beboard.getModules()]
 
-        test_list = CompositeTests[self.info] if isCompositeTest(self.info) else (self.info,)
-        self.module_test_history = {module.getModuleName():{test:{"Passed":0,"Failed":0} for test in test_list} for module in self.modules}
         
         self.GADC_meas_chip = None
         self.VDDDup = {channel:{} for channel in self.instruments._module_dict}
@@ -105,7 +103,6 @@ class TestHandler(QObject):
 
         self.SLDOfilelist = []
 
-        self.finished_tests = []
         self.BBanalysis_root_files = []
 
         self.numChips = len(
@@ -126,6 +123,21 @@ class TestHandler(QObject):
         else:
             self.boardType = "RD53A"
             self.moduleVersion = ""
+
+        self.registerKey = "{0}_HDIv{1}".format(self.ModuleType.replace(" ", "_"), self.hdiVersion)
+
+        #If the module is not one of the module types in CompositeTests_Modules, use the default test list
+        try:
+            print(CompositeTests_Modules)
+            print(CompositeTests_Modules[self.registerKey])
+            self.test_list = CompositeTests_Modules[self.registerKey][self.info] if isCompositeTest(self.info) else (self.info,)
+            print(f"Using test list {self.test_list} for ModuleType {self.registerKey} and Test {self.info}.")
+        except KeyError:
+            logger.error(f"Test {self.info} not found in CompositeTests_Modules for ModuleType {self.registerKey}.")
+            self.test_list = CompositeTests_Modules["Default"][self.info]
+
+        self.module_test_history = {module.getModuleName():{test:{"Passed":0,"Failed":0} for test in self.test_list} for module in self.modules}
+        self.finished_tests = []
         self.Ph2_ACF_ver = os.environ.get("Ph2_ACF_VERSION")
         print("Using version {0} of Ph2_ACF".format(self.Ph2_ACF_ver))
         self.firmwareImage = firmware_image[self.ModuleType][self.Ph2_ACF_ver]
@@ -270,7 +282,7 @@ class TestHandler(QObject):
 
         # If currentTest is not set check if it's a compositeTest and if so set testname accordingly, otherwise set it based off the test set in info[1]
         if self.currentTest == "" and isCompositeTest(self.info):
-            testName = CompositeTests[self.info][0]
+            testName = self.test_list[0]
         elif self.currentTest is None:
             testName = self.info
         else:
@@ -394,9 +406,9 @@ class TestHandler(QObject):
     def runCompositeTest(self, testName):
         if self.halt:
             return
-        runTestList = CompositeTests[self.info]
+        runTestList = self.test_list
 
-        if self.testIndexTracker == len(CompositeTests[self.info]):
+        if self.testIndexTracker == len(self.test_list):
             self.testIndexTracker = 0
             self.testsAttempted = 0
             return
@@ -471,6 +483,8 @@ class TestHandler(QObject):
             for i in range(len(self.firmware)):
                 self.runwindow.ResultWidget.ProgressBars[i][self.testIndexTracker].setValue(100)
             return
+
+
 
         print("Executing Single Step test...")
         for console in self.runwindow.ConsoleViews:
@@ -829,7 +843,8 @@ class TestHandler(QObject):
                             runNumber,
                             module_data,
                             self.BBanalysis_root_files,
-                            self.info
+                            self.info,
+                            self.registerKey
                         )
 
                         results.append(result)
@@ -1300,7 +1315,7 @@ created by Ph2_ACF is empty."
         # Will send signal to turn off power supply after composite or single tests are run
         if isCompositeTest(self.info):
             if index == len(
-                CompositeTests[self.info]
+                self.test_list
             ):  # Checks that this was the last test in the sequence.
                 self.powerSignal.emit()
                 EnableReRun = True
@@ -1476,7 +1491,7 @@ created by Ph2_ACF is empty."
 
         # Will send signal to turn off power supply after composite or single tests are run
         if isCompositeTest(self.info):
-            if self.testIndexTracker == len(CompositeTests[self.info]):
+            if self.testIndexTracker == len(self.test_list):
                 self.powerSignal.emit()
                 EnableReRun = True
                 if self.autoSave:
@@ -1541,7 +1556,7 @@ created by Ph2_ACF is empty."
                 ),
             )
 
-            if self.testIndexTracker == len(CompositeTests[self.info]):
+            if self.testIndexTracker == len(self.test_list):
                 self.powerSignal.emit()
                 EnableReRun = True
                 if self.autoSave:

--- a/Gui/python/TestValidator.py
+++ b/Gui/python/TestValidator.py
@@ -1,7 +1,7 @@
 import os
 import ROOT
 
-from InnerTrackerTests.TestSequences import Test_to_Ph2ACF_Map, CompositeTests
+from InnerTrackerTests.TestSequences import Test_to_Ph2ACF_Map, CompositeTests_Modules
 from Gui.GUIutils.guiUtils import isCompositeTest
 from Gui.python.logging_config import logger
 
@@ -16,14 +16,15 @@ def ResultGrader(
     runNumber,
     module_data,
     BBanalysis_root_files,
-    sequence
+    sequence,
+    registerKey
 ):
     try:
 
-        if isCompositeTest(sequence) and CompositeTests[sequence][testIndexInSequence] != testName:
+        if isCompositeTest(sequence) and CompositeTests_Modules[registerKey][sequence][testIndexInSequence] != testName:
             logger.error(
                 f"Test name didn't match expected test sequence name\n"
-                f"Expected Test Name: {CompositeTests[sequence][testIndexInSequence]}\n"
+                f"Expected Test Name: {CompositeTests_Modules[registerKey][sequence][testIndexInSequence]}\n"
                 f"Received Test Name: {testName}"
             )
             raise Exception("Test name doesn't match expected sequence name! Something went wrong.")


### PR DESCRIPTION
## Description
Added functionality for tests that depend on module type i.e. Data Splitting / Merging

## Checklist
Before submitting this PR, please ensure the following:

- [X] I am using the **correct branches/versions** of all submodules.
- [X] I have successfully **launched the Simplified GUI**.
- [X] I have successfully **run a test in the Simplified GUI**.
- [x] I have successfully **run a test in the Expert GUI**.

## Changes Made
Test Sequences now creates a nested dictionary with module types as keys and test dictionaries as the values. This allows us to run different tests depending on module types. Functionality has been added for double and quads for TFPX. Any other module will take the default test dictionary

## Testing
Tested on SH0012 and RH0107 to ensure doubles and quads work. Also tested the default case.

## Additional Notes
The actual data splitting test added into Inner Tracker is not functional since it is just a copy of the standard lane outputs for doubles. Will need to be changed in FELaneConfig.py
