### PR TITLE
Feature to add modules for thermal chamber in GUI. fixed GADC error bars and added multipliers

### DIFF
--- a/Gui/python/TestHandler.py
+++ b/Gui/python/TestHandler.py
@@ -1242,14 +1242,18 @@ created by Ph2_ACF is empty."
                 if match:
                     if self.GADC_meas_chip is not None:
                         if match.group(1) in ("VDDD","VDDA","VINA","VIND"):
+                            multiplier = site_settings.SLDOScan_GADC["multipliers"][match.group(1)[:3]]
+                            
                             if self.GADC_meas_chip not in getattr(self, match.group(1)+upOrDown)[channel]:
                                 getattr(self, match.group(1)+upOrDown)[channel][self.GADC_meas_chip] = {}
-                            getattr(self, match.group(1)+upOrDown)[channel][self.GADC_meas_chip][current] = match.group(2) #This line enforces that it only logs one VDDD or VDDA value per sweep step
+                            getattr(self, match.group(1)+upOrDown)[channel][self.GADC_meas_chip][current] = float(match.group(2))*multiplier #This line enforces that it only logs one VDDD or VDDA value per sweep step
 
                             if self.GADC_meas_chip not in getattr(self, match.group(1)+upOrDown+"Error")[channel]:
                                 getattr(self, match.group(1)+upOrDown+"Error")[channel][self.GADC_meas_chip] = {}
-                            getattr(self, match.group(1)+upOrDown+"Error")[channel][self.GADC_meas_chip][current] = match.group(3) #This line enforces that it only logs one VDDD or VDDA value per sweep step
+                            getattr(self, match.group(1)+upOrDown+"Error")[channel][self.GADC_meas_chip][current] = float(match.group(3))*multiplier #This line enforces that it only logs one VDDD or VDDA value per sweep step
                     else:
+                        print(f'Error: Did not receive expected message, "Reading monitored data for \
+                        [board/opticalGroup/hybrid/chip = ...]", before measurement message "{match.group(0)}"')
                         logger.error(f'Did not receive expected message, "Reading monitored data for \
                         [board/opticalGroup/hybrid/chip = ...]", before measurement message "{match.group(0)}"')
         

--- a/Gui/siteConfig.py
+++ b/Gui/siteConfig.py
@@ -88,7 +88,8 @@ SLDOScan_GADC = {
 		"target current":7,
 		"step size":.5
 	},
-    "physics seconds": 1.5*int(Monitor_SleepTime['SLDOScan_GADC'])/1000
+    "physics seconds": 1.5*int(Monitor_SleepTime['SLDOScan_GADC'])/1000,
+    "multipliers":{"VDD":2, "VIN":4}
 }
 
 forward_bias_voltage = 0.5 #positive voltage used to run a forward-reverse bias bump bond test


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of the changes in this PR. -->
Put combo box in GUI to add modules, so we can send what models have been thermal chambered to Panthera. Also in SLDOScan_GADC, the error bars work here, and I added multipliers for the VDDx, VINx values

## Checklist
Before submitting this PR, please ensure the following:

- [x] I am using the **correct branches/versions** of all submodules.
- [x] I have successfully **launched the Simplified GUI**.
- [x] I have successfully **run a test in the Simplified GUI**.
- [x] I have successfully **run a test in the Expert GUI**.

## Related Issues
<!-- List any related issues, e.g. "Fixes #123" or "Closes #456". -->

## Changes Made
<!-- Summarize the major changes in this PR. -->
Added ThermalProfile(Combo/Button) to QTApplication. Added "multipliers" key in SLDOScan_GADC in siteConfig.py and implemented the functionality for those.

## Testing
<!-- Describe how you tested your changes, including commands run, configurations used, etc. -->
Ran SLDOScan_GADC in expert mode on SH0012 and played around with the combo box in the home window.

## Additional Notes
<!-- Add any additional comments or context if needed. -->
