### PR TITLE
vref values from DB to XML (v2)

### DIFF
--- a/Gui/GUIutils/guiUtils.py
+++ b/Gui/GUIutils/guiUtils.py
@@ -11,7 +11,6 @@ import sys
 import os
 from datetime import datetime, timedelta
 from subprocess import Popen, PIPE
-from InnerTrackerTests.FESettings import FESettingsB_dict
 
 from Gui.GUIutils.settings import (
     updatedGlobalValue,
@@ -36,6 +35,7 @@ from InnerTrackerTests.GlobalSettings import (
 from InnerTrackerTests.FESettings import (
     FESettings_DictA,
     FESettings_DictB,
+    FESettingsB_dict,
 )
 from InnerTrackerTests.HWSettings import (
     HWSettings_DictA,
@@ -456,7 +456,10 @@ def GenerateXMLConfig(BeBoard, testName, outputDir, txt_files:dict, **arg):
                     txt_file,
                 )
 
-                FEChip.ConfigureFE(FESettings_Dict[testName][registerKey])
+                chip_settings = FESettings_Dict[testName][registerKey].copy()
+                chip_settings['VREF_ADC'] = chip.getVREF()
+                FEChip.ConfigureFE(chip_settings)
+            
                 if testName in FELaneConfig_Dict:
                         FEChip.ConfigureLaneConfig(
                             FELaneConfig_Dict[testName][int(chip.getLane())]

--- a/Gui/python/CustomizedWidget.py
+++ b/Gui/python/CustomizedWidget.py
@@ -312,6 +312,14 @@ class ChipBox(QWidget):
     def getEfuseID(self, pChipID):
         efuseID = self.findChild(QLineEdit, "EfuseIDEdit_{0}".format(pChipID))
         return efuseID.text()
+    
+    def getIREF(self, pChipID):
+        IREFthing = self.chipData[pChipID]["IREF"]
+        return IREFthing
+    
+    def getVREF(self, pChipID):
+        VREFthing = self.chipData[pChipID]["VREF"]
+        return VREFthing
 
     def getChipData(self):
         return self.chipData
@@ -746,6 +754,17 @@ class BeBoardBox(QWidget):
                 )
                 Module.getChips()[chipID].setEfuseID(
                     self.ChipWidgetDict[module].getEfuseID(chipID)
+                )
+                Module.getChips()[chipID].setIREF(
+                    self.ChipWidgetDict[module].getIREF(chipID)
+                )
+                try:
+                    vref_value = float(self.ChipWidgetDict[module].getVREF(chipID))
+                except Exception:
+                    vref_value = 0.8
+            
+                Module.getChips()[chipID].setVREF(
+                    int(round(1000 * vref_value))
                 )
 
             # Add the QtModule object to the currently selected Optical Group

--- a/Gui/python/Firmware.py
+++ b/Gui/python/Firmware.py
@@ -12,6 +12,8 @@ class QtChip:
         chipVDDA=0,
         chipVDDD=0,
         chipEfuseID=0,
+        chipVREF=800,
+        chipIREF="",
         chipStatus=True,
     ):
         self.__chipID = chipID
@@ -19,6 +21,8 @@ class QtChip:
         self.__chipVDDA = chipVDDA
         self.__chipVDDD = chipVDDD
         self.__chipEfuseID = chipEfuseID
+        self.__chipVREF = chipVREF
+        self.__chipIREF = chipIREF
         self.__chipStatus = chipStatus
 
     def setID(self, id: str):
@@ -50,6 +54,18 @@ class QtChip:
 
     def getEfuseID(self):
         return self.__chipEfuseID
+    
+    def setVREF(self, pVREF: int):
+        self.__chipVREF = pVREF
+
+    def getVREF(self):
+        return self.__chipVREF
+    
+    def setIREF(self, pIREF: int):
+        self.__chipIREF = pIREF
+
+    def getIREF(self):
+        return self.__chipIREF
 
     def setStatus(self, pStatus: bool):
         self.__chipStatus = pStatus


### PR DESCRIPTION
## Description
VREV values are pulled from the purdue database and put into the xml file

## Checklist
Before submitting this PR, please ensure the following:

- [x] I am using the **correct branches/versions** of all submodules.
- [x] I have successfully **launched the Simplified GUI**.
- [x] I have successfully **run a test in the Simplified GUI**.
- [x] I have successfully **run a test in the Expert GUI**.

## Related Issues
closes #516 

## Changes Made
CustomizedWidget: pulls the values from the database
GuiUtils: sets the VREF_ADC values in the FESEttings dicts as being the values that are pulled in CustomizedWidget. (if no values are pulled it defaults to 800 mV). + and i made a 1 line change to where an import is to make it a little cleaner


Firmware: get and set VREF and IREF value functions added. 

## Testing
ran pixelAlive on SH0012 and saw that the values default to 800 in the xml. ran the same on RH0104 and saw the values match those in the purdue database. 

## Additional Notes
<!-- Add any additional comments or context if needed. -->
