### PR TITLE
Removing some unnecessary code

### DIFF
--- a/Gui/python/TestHandler.py
+++ b/Gui/python/TestHandler.py
@@ -484,10 +484,7 @@ class TestHandler(QObject):
             self.output_dir, self.input_dir = self.config_output_dir(testName)
             self.currentTest = testName
 
-            if "CrossTalk" in testName:
-                EnableReRun = self.onFinalTest(self.testIndexTracker)
-            else:
-                EnableReRun = self.onFinalTest(self.testIndexTracker + 1)
+            EnableReRun = self.onFinalTest(self.testIndexTracker + 1)
             self.stepFinished.emit(EnableReRun)
 
             if self.master.expertMode:
@@ -1363,13 +1360,8 @@ created by Ph2_ACF is empty."
         # validate the results
         self.validateTest()
         
-        if (
-            "IVCurve" not in self.currentTest
-            and "SLDOScan" not in self.currentTest
-            and "CrossTalk" not in self.currentTest
-        ):
-            self.testIndexTracker += 1
-            self.testsAttempted += 1
+        self.testIndexTracker += 1
+        self.testsAttempted += 1
 
 
 


### PR DESCRIPTION
## Description
Removing some unnecessary lines in TestHandler that could be contributing to the test sequence ending after Crosstalk analysis even when it is not the last test in the series. Even if the issue is not fully fixed, the lines I removed are unnecessary anyways as I added them in PR 517 to fix the crosstalk indexing bug, but ended up just doing a "index -= 1" to get the indexing right anyways. 

## Checklist
Before submitting this PR, please ensure the following:

- [x] I am using the **correct branches/versions** of all submodules.
- [x] I have successfully **launched the Simplified GUI**.
- [x] I have successfully **run a test in the Simplified GUI**.
- [x] I have successfully **run a test in the Expert GUI**.

## Related Issues
could close issue number 521 (see description above)

## Changes Made
removed some lines that I added in #517 that I think could have caused the new issue in the first place. 

## Testing
ran TFPX Fullperformance Development test but pixel alive uncoupled xtalk kept failing. however this is not unlike what happens with the dev branch anyways. ran pixel_alive test as well and it worked fine

## Additional Notes
<!-- Add any additional comments or context if needed. -->
