### PR TITLE
CINJ value from DB into XML

### DIFF
--- a/Gui/GUIutils/guiUtils.py
+++ b/Gui/GUIutils/guiUtils.py
@@ -458,6 +458,7 @@ def GenerateXMLConfig(BeBoard, testName, outputDir, txt_files:dict, **arg):
 
                 chip_settings = FESettings_Dict[testName][registerKey].copy()
                 chip_settings['VREF_ADC'] = chip.getVREF()
+                #chip_settings['INJ_CAP'] = chip.getCINJ()          #Can uncomment once INJ_CAP is implemented into the dictionary for the XML
                 FEChip.ConfigureFE(chip_settings)
             
                 if testName in FELaneConfig_Dict:

--- a/Gui/python/CustomizedWidget.py
+++ b/Gui/python/CustomizedWidget.py
@@ -329,6 +329,10 @@ class ChipBox(QWidget):
     def getVREF(self, pChipID):
         VREFthing = self.chipData[pChipID]["VREF"]
         return VREFthing
+    
+    def getCINJ(self, pChipID):
+        CINJthing = self.chipData[pChipID]["CINJ"]
+        return CINJthing
 
     def getChipData(self):
         return self.chipData
@@ -771,9 +775,15 @@ class BeBoardBox(QWidget):
                     vref_value = float(self.ChipWidgetDict[module].getVREF(chipID))
                 except Exception:
                     vref_value = 0.8
-            
                 Module.getChips()[chipID].setVREF(
-                    int(round(1000 * vref_value))
+                    (1000 * vref_value)
+                )
+                try:
+                    cinj_value = float(self.ChipWidgetDict[module].getCINJ(chipID))
+                except Exception:
+                    cinj_value = 8
+                Module.getChips()[chipID].setCINJ(
+                    (10 * cinj_value)
                 )
 
             # Add the QtModule object to the currently selected Optical Group

--- a/Gui/python/Firmware.py
+++ b/Gui/python/Firmware.py
@@ -14,6 +14,7 @@ class QtChip:
         chipEfuseID=0,
         chipVREF=800,
         chipIREF="",
+        chipCINJ=80,
         chipStatus=True,
     ):
         self.__chipID = chipID
@@ -23,6 +24,7 @@ class QtChip:
         self.__chipEfuseID = chipEfuseID
         self.__chipVREF = chipVREF
         self.__chipIREF = chipIREF
+        self.__chipCINJ = chipCINJ
         self.__chipStatus = chipStatus
 
     def setID(self, id: str):
@@ -66,6 +68,12 @@ class QtChip:
 
     def getIREF(self):
         return self.__chipIREF
+    
+    def setCINJ(self, pCINJ: int):
+        self.__chipCINJ = pCINJ
+    
+    def getCINJ(self):
+        return self.__chipCINJ
 
     def setStatus(self, pStatus: bool):
         self.__chipStatus = pStatus


### PR DESCRIPTION
## Description
CINJ values pulled from the database and put into the xml just like the vref values.

## Checklist
Before submitting this PR, please ensure the following:

- [x] I am using the **correct branches/versions** of all submodules.
- [x] I have successfully **launched the Simplified GUI**.
- [x] I have successfully **run a test in the Simplified GUI**.
- [x] I have successfully **run a test in the Expert GUI**.

## Related Issues
<!-- List any related issues, e.g. "Fixes #123" or "Closes #456". -->

## Changes Made
CINJ values will go into the xml file

## Testing
added some lines to parse the .getCINJ values to the terminal and ran functional test and saw it matches with the DB.

## Additional Notes
doesnt go into the XML yet because the CAP_INJ label thing is not yet made for the XML (see commented out line 461 in guiUtils.py)
