### PR TITLE
GetModule in customized widget auto capitalizes

### DIFF
--- a/Gui/python/CustomizedWidget.py
+++ b/Gui/python/CustomizedWidget.py
@@ -142,7 +142,7 @@ class ModuleBox(QWidget):
                 self.VersionCombo.setCurrentText(1)
 
     def getSerialNumber(self):
-        return self.SerialEdit.text()
+        return self.SerialEdit.text().upper()
 
     def getFMCID(self):
         return self.FMCEdit.text()


### PR DESCRIPTION
## Description
Fixed bug with lowercase modules. Panthera now will only receive capitalized module names. i.e. "SH0102" never "sh0102".

## Checklist
Before submitting this PR, please ensure the following:

- [X] I am using the **correct branches/versions** of all submodules.
- [X] I have successfully **launched the Simplified GUI**.
- [X] I have successfully **run a test in the Simplified GUI**.
- [X] I have successfully **run a test in the Expert GUI**.

## Related Issues
Fixes #563 
## Changes Made
Customized widget getModuleName capitalizes module input

## Testing
Uploaded to panthera with a lowercase module name "rh0109" input and verified that panthera only recieves capitalized module. 


