### PR TITLE
Fixed abort button for IV Curve

### DIFF
--- a/Gui/python/IVCurveHandler.py
+++ b/Gui/python/IVCurveHandler.py
@@ -75,10 +75,15 @@ class IVCurveThread(QThread):
                 delay=0.2,
                 measure=True,
                 execute_each_step=self.getProgress,
+                break_loop= lambda: self.exiting,
             )[0]
 
-            # The physics test can be stopped by pressing enter
 
+            if self.exiting:
+                print("IV Curve scan was aborted by user.")
+                return
+                        
+            # The physics test can be stopped by pressing enter
             measurementStr = {
                 "voltage": [value[4] for value in measurements],
                 "current": [value[5] for value in measurements],


### PR DESCRIPTION
## Description
Abort button has issues working properly during voltage sweeps. IV curve abort will now work as intended 

## Checklist
Before submitting this PR, please ensure the following:

- [X] I am using the **correct branches/versions** of all submodules.
- [X] I have successfully **launched the Simplified GUI**.
- [X] I have successfully **run a test in the Simplified GUI**.
- [X] I have successfully **run a test in the Expert GUI**.

## Changes Made
IVCurveHandler now makes use of break_loop kwarg from icicle instrument.py

## Testing
Ran SH0012 and aborted mid hv sweep. IV curve stopped increasing voltage and swept down to 0. 


