### PR TITLE
clear dictionary when FMC port incorrectly input

### DIFF
--- a/Gui/python/CustomizedWidget.py
+++ b/Gui/python/CustomizedWidget.py
@@ -790,6 +790,8 @@ class BeBoardBox(QWidget):
             try:
                 OpticalGroup.addModule(FMCPort=module.getFMCPort(), module=Module)
             except KeyError as e:
+                if module.getFMCPort() in OpticalGroup.getAllModules():
+                    OpticalGroup.removeModuleByIndex(module.getFMCPort())
                 return None, f"Error while adding Module to Optical Group: {repr(e)}"
 
             module_types.append(
@@ -1218,6 +1220,8 @@ class SimpleBeBoardBox(QWidget):
                         FMCID=cable_properties["FMCID"], OpticalGroup=OpticalGroup
                     )
                 except KeyError as e:
+                    if module.getFMCID() in BeBoard.getAllOpticalGroups():
+                        BeBoard.removeOpticalGroup(module.getFMCID())
                     return (
                         None,
                         f"Error while adding Optical Group to BeBoard: {repr(e)}",


### PR DESCRIPTION
## Description
clears the dictionary of fmc ports after an error occurs so that upon the 2nd time the ports are input, it does not give the same error as the first, as long as the ports are input correctly.

## Checklist
Before submitting this PR, please ensure the following:

- [x] I am using the **correct branches/versions** of all submodules.
- [x] I have successfully **launched the Simplified GUI**.
- [x] I have successfully **run a test in the Simplified GUI**.
- [x] I have successfully **run a test in the Expert GUI**.

## Related Issues
fixes issue 556

## Changes Made
small changes within customizedWidget to clear the module fmc ports after an error

## Testing
ran functional test on sh0012, have not yet ran with 2 modules though

## Additional Notes
<!-- Add any additional comments or context if needed. -->
