### PR TITLE
Auto fmc

### DIFF
--- a/Gui/python/CustomizedWidget.py
+++ b/Gui/python/CustomizedWidget.py
@@ -83,10 +83,6 @@ class ModuleBox(QWidget):
         self.SerialEdit = QLineEdit()
         self.SerialEdit.setMinimumWidth(55)
 
-        FMCLabel = QLabel("FMC:")
-        self.FMCEdit = QLineEdit()
-        self.FMCEdit.setText("L12")
-
         PortLabel = QLabel("FMC port:")
         self.PortEdit = QLineEdit()
 
@@ -113,8 +109,6 @@ class ModuleBox(QWidget):
 
         self.mainLayout.addWidget(SerialLabel, 0, 0, 1, 1)
         self.mainLayout.addWidget(self.SerialEdit, 0, 1, 1, 1)
-        self.mainLayout.addWidget(FMCLabel, 0, 2, 1, 1)
-        self.mainLayout.addWidget(self.FMCEdit, 0, 3, 1, 1)
         self.mainLayout.addWidget(FC7Label, 0, 4, 1, 1)
         self.mainLayout.addWidget(self.FC7Combo, 0, 5, 1, 1)
         self.mainLayout.addWidget(PortLabel, 0, 6, 1, 1)
@@ -142,11 +136,21 @@ class ModuleBox(QWidget):
             else:
                 self.VersionCombo.setCurrentText(1)
 
+    def checkPort(self, port):
+        try:
+            if port in range(0,2):
+                return "L12"
+            elif port in range (3,4):
+                return "L8"
+        except:
+            logger.error(traceback.format_exc())
+            return "L12"
+
     def getSerialNumber(self):
         return self.SerialEdit.text().upper()
 
     def getFMCID(self):
-        return self.FMCEdit.text()
+        return self.checkPort(self.getFMCPort())
 
     def getFC7(self):
         return self.FC7Combo.currentText()

--- a/Gui/python/CustomizedWidget.py
+++ b/Gui/python/CustomizedWidget.py
@@ -142,6 +142,9 @@ class ModuleBox(QWidget):
                 return "L12"
             elif port in range (3,4):
                 return "L8"
+            else:
+                logger.warning(f"Unknown port: {port}")
+                return "L12"
         except:
             logger.error(traceback.format_exc())
             return "L12"
@@ -150,7 +153,7 @@ class ModuleBox(QWidget):
         return self.SerialEdit.text().upper()
 
     def getFMCID(self):
-        return self.checkPort(self.getFMCPort())
+        return self.checkPort(int(self.getFMCPort()))
 
     def getFC7(self):
         return self.FC7Combo.currentText()


### PR DESCRIPTION
## Description
FMC textbox has been removed from customized widget and is now automatically set by the FMC port associated with the module

## Checklist
Before submitting this PR, please ensure the following:

- [X] I am using the **correct branches/versions** of all submodules.
- [X] I have successfully **launched the Simplified GUI**.
- [X] I have successfully **run a test in the Simplified GUI**.
- [X] I have successfully **run a test in the Expert GUI**.

## Related Issues
Fixes #581 

## Changes Made
getFMCID function now checks FMC port and returns L8 or L12 

## Testing
Ran pixelAlive on both L12 and L8 to ensure both lanes work 