### PR TITLE
Don't add BeBoard multiple times to HWDescription

### DIFF
--- a/Gui/GUIutils/guiUtils.py
+++ b/Gui/GUIutils/guiUtils.py
@@ -98,7 +98,6 @@ def ConfigureTest(Test, Module_ID, Output_Dir, Input_Dir):
             + "_"
             + str(time_stamp)
         )
-        print(f"OUTPUT_DIR: {Output_Dir}")
         try:
             os.makedirs(Output_Dir)
         except OSError as e:
@@ -496,11 +495,10 @@ def GenerateXMLConfig(BeBoard, testName, outputDir, txt_files:dict, **arg):
 
         BeBoardModule0.AddOGModule(OpticalGroupModule0)
 
-        BeBoardModule0.SetURI(BeBoard.getIPAddress())
-        BeBoardModule0.SetBeBoard(BeBoard.getBoardID(), "RD53")
-
-        BeBoardModule0.SetRegisterValue(RegisterSettingsList)
-        HWDescription0.AddBeBoard(BeBoardModule0)
+    BeBoardModule0.SetURI(BeBoard.getIPAddress())
+    BeBoardModule0.SetBeBoard(BeBoard.getBoardID(), "RD53")
+    BeBoardModule0.SetRegisterValue(RegisterSettingsList)
+    HWDescription0.AddBeBoard(BeBoardModule0)
     HWSettings_Dict[testName]["DataOutputDir"] = BeBoard.getBoardName()
     HWDescription0.AddSettings(HWSettings_Dict[testName])
     MonitoringModule0 = MonitoringModule(boardtype)


### PR DESCRIPTION
## Description
This fixes an issue where optical groups were duplicated in the Ph2_ACF XML file


## Related Issues
Closes #585 

## Changes Made
Just removed an indent from BeBoard sectin of GenerateXML. Previously this was causing the BeBoard to be duplicated for every optical group. 


## Additional Notes
We only checked that the XML did not duplicate and looks more or less right. We couldn't test because our multi module test station is currently down. We are hoping UIC will report of any issues. 
