### PR TITLE
Update Peltier shutdown

### DIFF
--- a/Gui/QtGUIutils/QtApplication.py
+++ b/Gui/QtGUIutils/QtApplication.py
@@ -1336,22 +1336,23 @@ class QtApplication(QWidget):
                 self.instruments.off()
 
             # If you didn't start the Peltier controller, tempPower won't be defined
-            try:
-                if self.expertMode:
-                    self.PeltierCooling.shutdown()
-                else:
-                    self.SimpleMain.worker.abort_worker()
-                    self.SimpleMain.Peltier.sendCommand(
-                        self.SimpleMain.Peltier.createCommand(
-                            "Power On/Off Write",
-                            ["0", "0", "0", "0", "0", "0", "0", "0"],
+            if site_settings.cooler == "Peltier":
+                try:
+                    if self.expertMode:
+                        self.PeltierCooling.shutdown()
+                    else:
+                        self.SimpleMain.worker.abort_worker()
+                        self.SimpleMain.Peltier.sendCommand(
+                            self.SimpleMain.Peltier.createCommand(
+                                "Power On/Off Write",
+                                ["0", "0", "0", "0", "0", "0", "0", "0"],
+                            )
                         )
-                    )
-
-            except Exception as e:
-                logger.error(f"Could not shutdown Peltier: {e}")
-                logger.error(traceback.format_exc())
-                pass
+    
+                except Exception as e:
+                    logger.error(f"Could not shutdown Peltier: {e}")
+                    logger.error(traceback.format_exc())
+                    pass
 
             try:
                 os.system("rm -r {}/Gui/.tmp/*".format(os.environ.get("GUI_dir")))


### PR DESCRIPTION
Previously GUI always attempted to shutdown peltier no matter if you were using it or not. This leads to an error always being printed out when the GUI is closed and I believe can be the source of a dramatic slowdown.

Single line change. Not filling out the entirety of the MR template >:(