### PR TITLE
Fixed retry button bug

### DIFF
--- a/Gui/python/TestHandler.py
+++ b/Gui/python/TestHandler.py
@@ -2321,7 +2321,8 @@ created by Ph2_ACF is empty."
 
         def handle_retry():
             if check_enabledModules():
-                self.outputString.emit(f"Retrying {self.currentTest}...")
+                for console in self.runwindow.ConsoleViews:
+                    self.outputString.emit(f"Retrying {self.currentTest}...",console)
                 for i in range(len(self.firmware)):
                     self.runwindow.ResultWidget.runtimes[i][
                         self.testIndexTracker


### PR DESCRIPTION
## Description
Console printing was not handled correctly in retry button. Simple fix

## Checklist
Before submitting this PR, please ensure the following:

- [X] I am using the **correct branches/versions** of all submodules.
- [X] I have successfully **launched the Simplified GUI**.
- [X] I have successfully **run a test in the Simplified GUI**.
- [X] I have successfully **run a test in the Expert GUI**.

## Related Issues
Fixes #598 

## Testing
Ran functional test sequence with no module to trigger the fail window. Ensured test would retry correctly. 