### PR TITLE
fixing iref_gadc test bug for multi-fc7 tests

### DIFF
--- a/Gui/python/TestHandler.py
+++ b/Gui/python/TestHandler.py
@@ -1408,7 +1408,7 @@ created by Ph2_ACF is empty."
                         logger.error(traceback.format_exc())
                         pass
 
-                if self.check_for_end_of_test(textStr):
+                if self.check_for_end_of_test(textStr, processIndex):
                     self.runwindow.ResultWidget.ProgressBars[processIndex][
                         self.testIndexTracker
                     ].setValue(100)
@@ -1498,7 +1498,7 @@ created by Ph2_ACF is empty."
             # This next block needs to be edited once Ph2ACF bug is fixed.  Remove the Fixme when ready.
 
             elif self.ProgressingMode[processIndex] == ProgressMode.SUMMARY:
-                if self.check_for_end_of_test(textStr):
+                if self.check_for_end_of_test(textStr, processIndex):
                     self.runwindow.ResultWidget.ProgressBars[processIndex][
                         self.testIndexTracker
                     ].setValue(100)
@@ -1593,7 +1593,7 @@ created by Ph2_ACF is empty."
         except Exception:
             logger.error(traceback.format_exc())
 
-    def check_for_end_of_test(self, textStr):
+    def check_for_end_of_test(self, textStr, processIndex=0):
         # function to support the quick fix in on_readyReadStandardOutput() where
         # the progress bar doesn't always reach 100%.
         currentTest = Test_to_Ph2ACF_Map[self.currentTest]


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of the changes in this PR. -->
IREF_GADC test wasn't properly handling the processIndex for running mulitiple fc7s.  Now passing it to the function that checks if the test has finished.

## Checklist
Before submitting this PR, please ensure the following:

- [x] I am using the **correct branches/versions** of all submodules.
- [x] I have successfully **launched the Simplified GUI**.
- [x] I have successfully **run a test in the Simplified GUI**.
- [x] I have successfully **run a test in the Expert GUI**.

## Related Issues
<!-- List any related issues, e.g. "Fixes #123" or "Closes #456". -->

## Changes Made
<!-- Summarize the major changes in this PR. -->

## Testing
<!-- Describe how you tested your changes, including commands run, configurations used, etc. -->

## Additional Notes
<!-- Add any additional comments or context if needed. -->
