### PR TITLE
combined the xtalk tests into one OpenBumpTest

### DIFF
--- a/Gui/python/TestHandler.py
+++ b/Gui/python/TestHandler.py
@@ -544,7 +544,7 @@ class TestHandler(QObject):
         else:
             nextTest = None
         self.runSingleTest(testName, nextTest)
-##################################################################################
+
     def runOpenBumpTest(self):
         self._openBumpTest_running = True
         self._openBumpTest_subtest_index = 0
@@ -552,8 +552,7 @@ class TestHandler(QObject):
         logger.info(f"Running OpenBumpTest subtest: {subtest}")
         self.currentTest = subtest
         self.runSingleTest(subtest)
-##################################################################################
-##################################################################################
+
     def ramp_progress_bar(self, max):
         voltages = [
             getattr(module["hv"], "voltage")

--- a/Gui/python/TestHandler.py
+++ b/Gui/python/TestHandler.py
@@ -63,7 +63,7 @@ from Gui.python.TrimbitHandler import TrimbitCurveHandler
 import Gui.siteSettings as site_settings
 from Gui.python.logging_config import get_logger
 from Gui.python.CustomizedWidget import chip_iref_db
-from InnerTrackerTests.TestSequences import CompositeTests_Modules, Test_to_Ph2ACF_Map
+from InnerTrackerTests.TestSequences import CompositeTests_Modules, Test_to_Ph2ACF_Map, OpenBumpTest
 
 
 logger = get_logger(__name__)
@@ -309,6 +309,9 @@ class TestHandler(QObject):
             module.getModuleName(): True for module in self.modules
         }  # Initialize all to True
 
+        self._openBumpTest_running = False
+        self._openBumpTest_subtest_index = 0
+
     def finished_run_process(self, _, exitStatus, i):
         logger.info("Inside finsihed_run_process")
         logger.info("Current exitStatus in finished_run_process: %s", exitStatus)
@@ -532,14 +535,25 @@ class TestHandler(QObject):
             # self.testsAttempted = 0
             return
         testName = runTestList[self.testIndexTracker]
-        if self.testIndexTracker + 1 < len(
-            runTestList
-        ):  # Check if there is a next test
+
+        if testName == "OpenBumpTest":
+            self.runOpenBumpTest()
+            return
+        if self.testIndexTracker + 1 < len(runTestList):
             nextTest = runTestList[self.testIndexTracker + 1]
         else:
             nextTest = None
         self.runSingleTest(testName, nextTest)
-
+##################################################################################
+    def runOpenBumpTest(self):
+        self._openBumpTest_running = True
+        self._openBumpTest_subtest_index = 0
+        subtest = OpenBumpTest[self._openBumpTest_subtest_index]
+        logger.info(f"Running OpenBumpTest subtest: {subtest}")
+        self.currentTest = subtest
+        self.runSingleTest(subtest)
+##################################################################################
+##################################################################################
     def ramp_progress_bar(self, max):
         voltages = [
             getattr(module["hv"], "voltage")
@@ -1801,6 +1815,22 @@ created by Ph2_ACF is empty."
             return
 
         self.finished_processes = 0
+
+        if self._openBumpTest_running:
+            self._openBumpTest_subtest_index += 1
+            if self._openBumpTest_subtest_index < len(OpenBumpTest):
+                subtest = OpenBumpTest[self._openBumpTest_subtest_index]
+                logger.info(f"Running next OpenBumpTest subtest: {subtest}")
+                self.currentTest = subtest
+                self.input_dir = self.output_dir  # Chain the output of the last test as input for the next
+                self.output_dir = "" # Reset output directory to force creation of a new one
+                self.runSingleTest(subtest)
+                return  # Skip normal finish routine
+            else:
+                # Finished all subtests
+                self._openBumpTest_running = False
+                self.currentTest = "OpenBumpTest"
+                logger.info("All OpenBumpTest subtests finished. Validating...")
 
         # validate the results
         logger.debug("About to run validateTest()")


### PR DESCRIPTION
## Description
made OpenBumpTest (OBT) a list of the xtalk tests in test sequences. when OBT is ran, it runs each xtalk as a subtest and then grades them together when they have all ran. still saves their data in separate directories. 

## Checklist
Before submitting this PR, please ensure the following:

- [x] I am using the **correct branches/versions** of all submodules.
- [x] I have successfully **launched the Simplified GUI**.
- [x] I have successfully **run a test in the Simplified GUI**.
- [x] I have successfully **run a test in the Expert GUI**.

## Related Issues
closes #590 

## Changes Made
created runOpenBumpTest function in TestHandler, which runs each subtest as a single test. updated on_finish method so that if it is in the middle of running openBumpTest, the whole test gets validated instead of after each individual subtest. 

## Testing
ran with rh0110, which failed 50% of the time, so I disabled chip 12 as that chip was messing it up, and then it worked 4 times in a row. 

## Additional Notes
requires the following to be added into TestSequences in InnerTrackerTests, and then the xtalks can be replaced with OpenBumpTest in the composite test lists. 

OpenBumpTest = [
    "PixelAlive_highcharge_xtalk",
    "PixelAlive_coupled_xtalk",
    "PixelAlive_uncoupled_xtalk",
]
