### PR TITLE
checking if hv is on before ramping

### DIFF
--- a/Gui/python/TestHandler.py
+++ b/Gui/python/TestHandler.py
@@ -870,20 +870,26 @@ class TestHandler(QObject):
                 "instrument_dict"
             ]["hv"]["default_voltage"]
             # assumes only 1 HV titled 'hv' in instruments.json
-            self.instruments.hv_on(voltage=0, delay=0.5, step_size=10, no_lock=True)
-            self.powergroup.enable_all()
-            print("trying to turn on HV")
-            self.powergroup.ramp_hv( ###  changed from hv_on_module to hv_on for testing
-                        #module=mod_dict[number],  ## removed for testing
-                voltage=default_hv_voltage,
-                delay=0.3,
-                step_size=10,
-                execute_each_step=lambda: self.ramp_progress_bar(
-                    [default_hv_voltage]
-                    * len(self.instruments._module_dict.values())
-                    ),
-                break_loop=lambda: self.halt,
-            )
+            hv_status = False
+            #Checking the status of the HV supply
+            for number in self.instruments.get_modules().keys():
+                if self.instruments.status()[number]["hv"] == "1":
+                    hv_status = True
+                    break
+            if not hv_status:
+                self.instruments.hv_on(voltage=0, delay=0.5, step_size=10, no_lock=True)
+                self.powergroup.enable_all()
+                print("trying to turn on HV")
+                self.powergroup.ramp_hv(
+                    voltage=default_hv_voltage,
+                    delay=0.3,
+                    step_size=10,
+                    execute_each_step=lambda: self.ramp_progress_bar(
+                        [default_hv_voltage]
+                        * len(self.instruments._module_dict.values())
+                        ),
+                    break_loop=lambda: self.halt,
+                )
             
 
         if "TrimbitScan" in testName:


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of the changes in this PR. -->
Adding a check to see if the HV is on before ramping up the HV.  This is to fix the bug introduced by the HVbox implementation where the HV was ramping down and then back up at the beginning of every test.  

## Checklist
Before submitting this PR, please ensure the following:

- [x] I am using the **correct branches/versions** of all submodules.
- [x] I have successfully **launched the Simplified GUI**.
- [x] I have successfully **run a test in the Simplified GUI**.
- [x] I have successfully **run a test in the Expert GUI**.

## Related Issues
<!-- List any related issues, e.g. "Fixes #123" or "Closes #456". -->

## Changes Made
<!-- Summarize the major changes in this PR. -->

## Testing
<!-- Describe how you tested your changes, including commands run, configurations used, etc. -->

## Additional Notes
<!-- Add any additional comments or context if needed. -->
