### PR TITLE
Update default coldbox temperature to start at -35

### DIFF
--- a/Gui/jsonFiles/instruments_osu_auto.json
+++ b/Gui/jsonFiles/instruments_osu_auto.json
@@ -17,7 +17,7 @@
         "cb": {
             "class": "PSIColdbox",
             "resource": "TCPIP::coldbox::1883::SOCKET",
-            "default_temperature": 5,
+            "default_temperature": -35,
             "temperature_tolerance": 0.5,
             "validation_time": 20,
             "validation_timeout": 600


### PR DESCRIPTION
## Description
The cold start test of the modules requires us to power on the modules at -35C. The easiest way to do this is to just set the default temperature to -35, then if the first test fails in a sequence, the cold start failed. 

## Checklist
Changed one number, no way the code doesn't run now. 

## Related Issues
Closes #628 

## Changes Made
Change default temperature in json file 

## Additional Notes
<!-- Add any additional comments or context if needed. -->
