### PR TITLE
IVCurve tests now reach 100% instead of stopping at 99

### DIFF
--- a/Gui/python/TestHandler.py
+++ b/Gui/python/TestHandler.py
@@ -2247,6 +2247,11 @@ created by Ph2_ACF is empty."
                 (step, self.figurelist)
             )  ##Add else statement to add signal in simple mode
 
+        for i, firmware in enumerate(self.firmware):
+            self.runwindow.ResultWidget.ProgressBars[i][
+                self.testIndexTracker
+            ].setValue(100)
+
         if isCompositeTest(self.info):
             self.runTest()
 


### PR DESCRIPTION
## Description
IVCurve tests now reach 100% instead of stopping at 99

## Checklist
Before submitting this PR, please ensure the following:

- [X] I am using the **correct branches/versions** of all submodules.
- [X] I have successfully **launched the Simplified GUI**.
- [X] I have successfully **run a test in the Simplified GUI**.
- [X] I have successfully **run a test in the Expert GUI**.
