### PR TITLE
LV turns off after coldbox. NOTE this requires having checkstatus

### DIFF
--- a/Gui/QtGUIutils/QtRunWindow.py
+++ b/Gui/QtGUIutils/QtRunWindow.py
@@ -147,13 +147,33 @@ class QtRunWindow(QWidget):
             np.abs(getattr(module["hv"], "voltage"))
             for module in self.master.instruments._module_dict.values()
         ]
-        self.master.instruments.off(
-            hv_delay=0.3,
-            hv_step_size=10,
-            measure=False,
-            execute_each_step=lambda: self.testHandler.ramp_progress_bar(
-                starting_voltages
-            ),
+        if site_settings.cooler == "Tessie":
+            if self.master.instruments:
+                starting_voltages = [
+                    np.abs(getattr(module["hv"], "voltage"))
+                    for module in self.master.instruments._module_dict.values()
+                ]
+                self.master.instruments.hv_off(
+                    delay=0.3,
+                    step_size=10,
+                    execute_each_step=lambda: self.testHandler.ramp_progress_bar(
+                    starting_voltages
+                ),                )
+            self.master.instruments.cb_off(checkstatus=False)
+            try:
+                    self.wait_for_temp()
+            except InstrumentTimeoutError:
+                    logger.error(traceback.format_exc())
+
+            self.master.instruments.lv_off()
+        else:
+            self.master.instruments.off(
+                hv_delay=0.3,
+                hv_step_size=10,
+                measure=False,
+                execute_each_step=lambda: self.testHandler.ramp_progress_bar(
+                    starting_voltages
+                ),
         )
 
     def setLoginUI(self):
@@ -711,25 +731,7 @@ class QtRunWindow(QWidget):
                 self.release()
                 print(f"self.master.instruments: {self.master.instruments}")
                 if self.master.instruments:
-                    starting_voltages = [
-                        np.abs(getattr(module["hv"], "voltage"))
-                        for module in self.master.instruments._module_dict.values()
-                    ]
-                    self.master.instruments.hv_off(
-                        delay=0.3,
-                        step_size=10,
-                        execute_each_step=lambda: self.testHandler.ramp_progress_bar(
-                            starting_voltages
-                        ),
-                    )
-                    self.master.instruments.cb_off(checkstatus=False)
-                    try:
-                        self.wait_for_temp()
-                    except InstrumentTimeoutError:
-                        logger.error(traceback.format_exc())
-                        print("Connection with coldbox timed out.  Now turning off lv")
-
-                    self.master.instruments.lv_off()
+                    self.onPowerSignal()
 
                 else:
                     QMessageBox.information(


### PR DESCRIPTION

## Description
I previously put LV off after CB code only when pressing finish button. Now it will happen for all instances of OnPowerSignal i.e. after test sequences 

## Checklist
Before submitting this PR, please ensure the following:

- [X] I am using the **correct branches/versions** of all submodules.
- [X] I have successfully **launched the Simplified GUI**.
- [X] I have successfully **run a test in the Simplified GUI**.
- [X] I have successfully **run a test in the Expert GUI**.


## Testing
1 Module in coldbox with single and composite tests