### PR TITLE
Progress Bar no longer cycles 3 times for openBumpTest

### DIFF
--- a/Gui/python/TestHandler.py
+++ b/Gui/python/TestHandler.py
@@ -195,6 +195,7 @@ class TestHandler(QObject):
         self.SLDOScanHandler = None
         self.trimbitHandler = None
         self.starttime = None
+        self._OBT_starttime = None
 
         self.processingFlag = False
         self.ProgresBarList = []
@@ -1496,6 +1497,11 @@ created by Ph2_ACF is empty."
                     self.fused_dict_index[1] = chip_number
                     # print(f"Clean_text: {clean_text}")
                     print(f"Chip Number: {chip_number}")
+
+                if self._openBumpTest_running:
+                    if self._OBT_starttime is None: 
+                        self._OBT_starttime = time.time()    
+                    self.starttime = self._OBT_starttime
 
                 if self.starttime is not None:
                     self.currentTime = time.time()

--- a/Gui/python/TestHandler.py
+++ b/Gui/python/TestHandler.py
@@ -1520,12 +1520,17 @@ created by Ph2_ACF is empty."
                         self.ProgressValue = float(
                             re.sub(r"\x1b\[\d+m", "", textStr.split()[index].strip("%"))
                         )
-                        if self.ProgressValue == 100:
-                            self.ProgressingMode[processIndex] = ProgressMode.SUMMARY
-                        self.runwindow.ResultWidget.ProgressBars[processIndex][
-                            self.testIndexTracker
-                        ].setValue(self.ProgressValue)
-                        ##Added because of Ph2_ACF bug:
+                        # Check if openBumpTest is running
+                        if self._openBumpTest_running:
+                            scaled_progress_value = (self._openBumpTest_subtest_index * (100/3) + (self.ProgressValue / 3))
+                            self.runwindow.ResultWidget.ProgressBars[processIndex][self.testIndexTracker].setValue(scaled_progress_value)
+
+                        else:
+                            if self.ProgressValue == 100:
+                                self.ProgressingMode[processIndex] = ProgressMode.SUMMARY
+                            self.runwindow.ResultWidget.ProgressBars[processIndex][
+                                self.testIndexTracker
+                            ].setValue(self.ProgressValue)
 
                     except Exception as e:
                         print(f"Error while updating progress bar {e}")


### PR DESCRIPTION
## Description
Scaled the progression of the progress bar/removed the resetting when openBumpTest is running, so that it does not cycle 3 times. it now cleanly goes from 0-100%. 

## Checklist
Before submitting this PR, please ensure the following:

- [x] I am using the **correct branches/versions** of all submodules.
- [x] I have successfully **launched the Simplified GUI**.
- [x] I have successfully **run a test in the Simplified GUI**.
- [x] I have successfully **run a test in the Expert GUI**.

## Related Issues
fixes #655 

## Changes Made
in TestHandler.py: 
-runtime uses OBT_starttime to measure runtime whenever OpenBumpTest_running is true. 
-progress bars value is set to a "scaled" progress value where it increments by 1% for every 3% of the subtest done, and also accounts for the progress already done by the previous subtest. 

## Testing
ran a few tests with pixelAlive and OpenBumpTest on SH0012. 

## Additional Notes
<!-- Add any additional comments or context if needed. -->
