### PR TITLE
Trimbit now ends chip test when exceeding stop voltage

### DIFF
--- a/Gui/python/TrimbitHandler.py
+++ b/Gui/python/TrimbitHandler.py
@@ -237,7 +237,7 @@ class TrimbitCurveWorker(QThread):
             if name.endswith(str(chip)) and name.startswith(measurement_type):
                 measurement = self.ADCmeasurements[pin][-1][1] if self.ADCmeasurements[pin] else None
                 if measurement is not None:
-                    return 0 if measurement > 1.29 else 1
+                    return 1
         return 0
     
     def check_stop_voltage(self, chip):

--- a/Gui/python/TrimbitHandler.py
+++ b/Gui/python/TrimbitHandler.py
@@ -103,15 +103,22 @@ class TrimbitCurveWorker(QThread):
         """
         self.trimbit_dict = {c: (0, 0) for c in self.chip_list}
         newTrim = np.array([0, 0])
+        steps_done = 0
 
         for _ in range(self.total_steps):
             if self.exiting:
                 break
             self.process_step(chip, newTrim)
+            steps_done += 1
             
             # Check if both VDDA and VDDD have exceeded stop voltage (1.29V)
             if self.check_stop_voltage(chip):
                 logger.info(f"Trimbit scan stopped early for chip {chip}: both voltages exceed 1.29V")
+                remaining_steps = self.total_steps - steps_done
+                if remaining_steps > 0:
+                    self.ProgressValue += remaining_steps
+                    percent = 100 * self.ProgressValue / (self.total_steps * len(self.chip_list))
+                    self.progressSignal.emit("TrimbitScan", percent)
                 break
 
     def process_step(self, chip, newTrim):
@@ -242,13 +249,13 @@ class TrimbitCurveWorker(QThread):
     
     def check_stop_voltage(self, chip):
         """
-        Checks if both VDDA and VDDD have exceeded the stop voltage threshold (1.29V).
+        Checks if either VDDA or VDDD has exceeded the stop voltage threshold (1.29V).
 
         Args:
             chip (int): The chip number to check.
 
         Returns:
-            bool: True if both VDDA and VDDD exceed 1.29V, False otherwise.
+            bool: True if either VDDA or VDDD exceeds 1.29V, False otherwise.
         """
         vdda_measurement = None
         vddd_measurement = None
@@ -260,9 +267,9 @@ class TrimbitCurveWorker(QThread):
                 elif name.startswith("VDDD") and self.ADCmeasurements[pin]:
                     vddd_measurement = self.ADCmeasurements[pin][-1][1]
         
-        # Return True only if both measurements exist and both exceed 1.29V
-        return (vdda_measurement is not None and vddd_measurement is not None and 
-                vdda_measurement > 1.29 and vddd_measurement > 1.29)
+        # Return True if either measurement exists and exceeds 1.29V
+        return ((vdda_measurement is not None and vdda_measurement > 1.29) or 
+                (vddd_measurement is not None and vddd_measurement > 1.29))
     
     def measureADC(self, chip):
         """

--- a/Gui/python/TrimbitHandler.py
+++ b/Gui/python/TrimbitHandler.py
@@ -108,6 +108,11 @@ class TrimbitCurveWorker(QThread):
             if self.exiting:
                 break
             self.process_step(chip, newTrim)
+            
+            # Check if both VDDA and VDDD have exceeded stop voltage (1.29V)
+            if self.check_stop_voltage(chip):
+                logger.info(f"Trimbit scan stopped early for chip {chip}: both voltages exceed 1.29V")
+                break
 
     def process_step(self, chip, newTrim):
         """
@@ -234,6 +239,30 @@ class TrimbitCurveWorker(QThread):
                 if measurement is not None:
                     return 0 if measurement > 1.29 else 1
         return 0
+    
+    def check_stop_voltage(self, chip):
+        """
+        Checks if both VDDA and VDDD have exceeded the stop voltage threshold (1.29V).
+
+        Args:
+            chip (int): The chip number to check.
+
+        Returns:
+            bool: True if both VDDA and VDDD exceed 1.29V, False otherwise.
+        """
+        vdda_measurement = None
+        vddd_measurement = None
+        
+        for pin, name in self.pin_mapping.items():
+            if name.endswith(str(chip)):
+                if name.startswith("VDDA") and self.ADCmeasurements[pin]:
+                    vdda_measurement = self.ADCmeasurements[pin][-1][1]
+                elif name.startswith("VDDD") and self.ADCmeasurements[pin]:
+                    vddd_measurement = self.ADCmeasurements[pin][-1][1]
+        
+        # Return True only if both measurements exist and both exceed 1.29V
+        return (vdda_measurement is not None and vddd_measurement is not None and 
+                vdda_measurement > 1.29 and vddd_measurement > 1.29)
     
     def measureADC(self, chip):
         """


### PR DESCRIPTION
## Description
Added a scan stop that ends the current chip test instead of just stopping the measurements.

## Checklist
Before submitting this PR, please ensure the following:

- [X] I am using the **correct branches/versions** of all submodules.
- [X] I have successfully **launched the Simplified GUI**.
- [X] I have successfully **run a test in the Simplified GUI**.
- [X] I have successfully **run a test in the Expert GUI**.

## Related Issues
Progress on #667 

## Testing
RH0110 Trimbit scan 

