### PR TITLE
Retry fix

### DIFF
--- a/Gui/GUIutils/guiUtils.py
+++ b/Gui/GUIutils/guiUtils.py
@@ -402,6 +402,8 @@ def GenerateXMLConfig(BeBoard, testName, outputDir, txt_files:dict, **arg):
 
         # Set up each module within the optical group
         for module in og.getAllModules().values():
+            if hasattr(module, "getEnabled") and str(module.getEnabled()) != "1":
+                continue
             HyBridModule0 = HyBridModule()
             HyBridModule0.SetHyBridModule(module.getFMCPort(), "1")
             HyBridModule0.SetHyBridName(module.getModuleName())

--- a/Gui/python/TestHandler.py
+++ b/Gui/python/TestHandler.py
@@ -278,6 +278,7 @@ class TestHandler(QObject):
         self.SLDOProgressValue = 0
         self.runtimeList = []
         self.starttime = None
+        self.active_process_count = len(self.run_processes)
 
         self.communicationTestResults = {
             module.getModuleName(): None for module in self.modules
@@ -318,6 +319,7 @@ class TestHandler(QObject):
         
         self._openBumpTest_running = False
         self._openBumpTest_subtest_index = 0
+        self._retrying = False
 
     def _module_is_enabled(self, module) -> bool:
         module_name = module.getModuleName()
@@ -328,8 +330,9 @@ class TestHandler(QObject):
         return [module for module in self.modules if self._module_is_enabled(module)]
 
     def finished_run_process(self, _, exitStatus, i):
-        logger.info("Inside finsihed_run_process")
+        logger.info("Inside finished_run_process")
         logger.info("Current exitStatus in finished_run_process: %s", exitStatus)
+        
         if exitStatus == QProcess.NormalExit:
             # Ensure that all processes have finished before continuing
             self.on_finish(i)
@@ -953,6 +956,9 @@ class TestHandler(QObject):
         self.tempindex = 0
         logger.info(f"{self.output_dir=}")
 
+        # Track how many processes actually start for this run.
+        self.active_process_count = 0
+
         # Create per-FC7 output directories
         # <output_dir>/<fc7>/output.txt
         # An error.txt file was created in the old version but never used.
@@ -1025,6 +1031,8 @@ class TestHandler(QObject):
                     "CMSITminiDAQ",
                     ["-f", f"CMSIT_{firmware.getBoardName()}.xml", "-p"],
                 )
+                if process.state() != QProcess.NotRunning:
+                    self.active_process_count += 1
 
         if (
             self.currentTest == "IREF_GADC"
@@ -1041,6 +1049,8 @@ class TestHandler(QObject):
                         "15",
                     ],
                 )
+                if process.state() != QProcess.NotRunning:
+                    self.active_process_count += 1
         elif self.currentTest == "TrimbitScan":
             for process, firmware in zip(self.run_processes, self.firmware):
                 process.start(
@@ -1050,6 +1060,8 @@ class TestHandler(QObject):
                         f"CMSIT_{firmware.getBoardName()}.xml",
                     ],
                 )
+                if process.state() != QProcess.NotRunning:
+                    self.active_process_count += 1
         else:
             i = 0
             for process, firmware in zip(self.run_processes, self.firmware):
@@ -1068,6 +1080,7 @@ class TestHandler(QObject):
                         f"Process for firmware {self.firmware[i].getBoardName()} failed to start."
                     )
                 else:
+                    self.active_process_count += 1
                     logger.info(
                         f"Process for firmware {self.firmware[i].getBoardName()} started successfully."
                     )
@@ -1076,6 +1089,12 @@ class TestHandler(QObject):
     def abortTest(self):
         self.halt = True
         for process in self.run_processes:
+            # Disconnect signals before killing to prevent unwanted finished signal
+            try:
+                process.finished.disconnect()
+                process.readyReadStandardOutput.disconnect()
+            except Exception:
+                pass
             process.kill()
 
         self.haltSignal.emit(self.halt)
@@ -1098,6 +1117,12 @@ class TestHandler(QObject):
 
     def urgentStop(self):
         for process in self.run_processes:
+            # Disconnect signals before killing to prevent unwanted finished signal
+            try:
+                process.finished.disconnect()
+                process.readyReadStandardOutput.disconnect()
+            except Exception:
+                pass
             process.kill()
         self.halt = True
         self.haltSignal.emit(self.halt)
@@ -1935,6 +1960,11 @@ created by Ph2_ACF is empty."
         # Wait for all processes to finish so FC7s don't get out of sync
 
         logger.debug("All processes finished")
+        
+        # If this is a retried test completing, clear the retry flag so it can proceed normally
+        if self._retrying:
+            self._retrying = False
+            logger.info("Retry test completing - clearing retry flag")
 
         if self.halt:
             self.haltSignal.emit(True)
@@ -1953,12 +1983,21 @@ created by Ph2_ACF is empty."
 
         if "IVCurve" in self.currentTest:
             self.saveTest(processIndex, self.run_processes[processIndex])
+            # Check if retry was triggered during saveTest
+            if self._retrying:
+                logger.info("Retry initiated during IVCurve saveTest - aborting on_finish")
+                return
             return
 
         # Save the output ROOT file to output_dir
         logger.debug("About to run saveTest()")
         time.sleep(1)
         self.saveTest(processIndex, self.run_processes[processIndex])
+        
+        # Check if retry was triggered during saveTest
+        if self._retrying:
+            logger.info("Retry initiated during saveTest - aborting on_finish")
+            return
 
         self.saveConfigs(process_index=processIndex)
         # Don't continue on sequence until all processes have finished the current test
@@ -1981,7 +2020,12 @@ created by Ph2_ACF is empty."
 
         # Ensure that all processes have finished before continuing
         self.finished_processes += 1
-        if not self.finished_processes == len(self.run_processes):
+        expected_processes = (
+            self.active_process_count
+            if self.active_process_count > 0
+            else len(self.run_processes)
+        )
+        if not self.finished_processes == expected_processes:
             return
 
         self.finished_processes = 0
@@ -2443,6 +2487,9 @@ created by Ph2_ACF is empty."
     def forceContinue(
         self, board
     ):  # board:QtBeBoard. Runs when module disconnection is suspected.
+        # Set retrying flag immediately to prevent on_finish from running while dialog is shown
+        self._retrying = True
+        
         fc7modules = board.getModules()
 
         # Create the main widget
@@ -2523,6 +2570,12 @@ created by Ph2_ACF is empty."
         def handle_close(event):
             if self.force_continue_window.abort:
                 for process in self.run_processes:
+                    # Disconnect signals before killing to prevent unwanted finished signal
+                    try:
+                        process.finished.disconnect()
+                        process.readyReadStandardOutput.disconnect()
+                    except Exception:
+                        pass
                     process.kill()
                 self.halt = True
                 self.haltSignal.emit(self.halt)
@@ -2540,6 +2593,36 @@ created by Ph2_ACF is empty."
 
         def handle_retry():
             if check_enabledModules():
+                # Set retrying flag to prevent on_finish from executing
+                self._retrying = True
+                
+                for i, process in enumerate(self.run_processes):
+                    # Disconnect signals then kill processes
+                    try:
+                        process.finished.disconnect()
+                        process.readyReadStandardOutput.disconnect()
+                        logger.info(f"Disconnected signals from old process {i}")
+                    except Exception as e:
+                        logger.debug(f"Could not disconnect signals from process {i}: {e}")
+                    
+                    if process.state() == QProcess.Running:
+                        process.kill()
+                        process.waitForFinished(-1)
+                    
+                    # Create new QProcess objects
+                    self.run_processes[i] = QProcess()
+                    self.run_processes[i].readyReadStandardOutput.connect(
+                        lambda j=i: self.on_readyReadStandardOutput(j)
+                    )
+                    self.run_processes[i].finished.connect(
+                        lambda exitCode, exitStatus, j=i: self.finished_run_process(
+                            exitCode, exitStatus, j
+                        )
+                    )
+                
+                # Reset finished_processes counter
+                self.finished_processes = 0
+                
                 for console in self.runwindow.ConsoleViews:
                     self.outputString.emit(f"Retrying {self.currentTest}...",console)
                 for i in range(len(self.firmware)):
@@ -2551,11 +2634,16 @@ created by Ph2_ACF is empty."
                     ].setValue(
                         0
                     )  # may need to .update(). Automatically adds "0%" text on Progress bar.
-                self.testIndexTracker -= 1
+                # Don't decrement testIndexTracker - we're retrying at the same position
                 self.force_continue_window.close()
+                
+                # Restart the test - _retrying will be cleared when the retry completes
+                self.runTest()
 
         def handle_continue():
             if check_enabledModules():
+                # Clear retrying flag to allow normal on_finish execution
+                self._retrying = False
                 self.force_continue_window.close()
 
         # Connect buttons to handlers

--- a/Gui/python/TestHandler.py
+++ b/Gui/python/TestHandler.py
@@ -116,6 +116,9 @@ class TestHandler(QObject):
         self.modules = [
             module for beboard in self.firmware for module in beboard.getModules()
         ]
+        self.statuses = {
+            module.getModuleName(): module.getEnabled() for module in self.modules
+        }
 
         self.GADC_meas_chip = None
         self.VDDDup = {channel: {} for channel in self.instruments._module_dict}
@@ -316,6 +319,14 @@ class TestHandler(QObject):
         self._openBumpTest_running = False
         self._openBumpTest_subtest_index = 0
 
+    def _module_is_enabled(self, module) -> bool:
+        module_name = module.getModuleName()
+        status = self.statuses.get(module_name, module.getEnabled())
+        return str(status) == "1"
+
+    def enabled_modules(self):
+        return [module for module in self.modules if self._module_is_enabled(module)]
+
     def finished_run_process(self, _, exitStatus, i):
         logger.info("Inside finsihed_run_process")
         logger.info("Current exitStatus in finished_run_process: %s", exitStatus)
@@ -325,7 +336,7 @@ class TestHandler(QObject):
 
     def initializeRD53Dict(self):
         self.rd53_file = {}
-        for module in self.modules:
+        for module in self.enabled_modules():
             ogId = module.getOpticalGroup().getOpticalGroupID()
             beboardId = module.getOpticalGroup().getBeBoard().getBoardID()
             moduleName = module.getModuleName()
@@ -343,7 +354,7 @@ class TestHandler(QObject):
 
     def config_output_dir(self, testName):
         ModuleIDs = []
-        for module in self.modules:
+        for module in self.enabled_modules():
             ModuleIDs.append(str(module.getModuleName()))
         # output_dir gets set to $DATA_dir/Test_{testname}/Test_Module{ModuleID}_{Test}_{TimeStamp}
         return ConfigureTest(
@@ -1222,6 +1233,8 @@ class TestHandler(QObject):
                 for OG in beboard.getAllOpticalGroups().values():
                     ogID = OG.getOpticalGroupID()
                     for module in OG.getAllModules().values():
+                        if not self._module_is_enabled(module):
+                            continue
                         print(f"curr test {self.currentTest}")
                         hybridID = module.getFMCPort()
                         module_data = {
@@ -1698,7 +1711,7 @@ created by Ph2_ACF is empty."
                 updatedFEKeys = optimizationTestMap[
                     Test_to_Ph2ACF_Map[self.currentTest]
                 ]
-                for module in self.modules:
+                for module in self.enabled_modules():
                     chipIDs = [
                         chip.getID()
                         for chip in module.getChips().values()
@@ -2023,6 +2036,8 @@ created by Ph2_ACF is empty."
                         for OG in beboard.getAllOpticalGroups().values():
                             ogID = OG.getOpticalGroupID()
                             for module in OG.getAllModules().values():
+                                if not self._module_is_enabled(module):
+                                    continue
                                 hybridID = module.getFMCPort()
                                 module_data = {
                                     "boardID": boardID,
@@ -2095,7 +2110,7 @@ created by Ph2_ACF is empty."
                 #].setValue(self.SLDOProgressValue)
 
     def makeSLDOPlot(self, total_result: np.ndarray, pin: str, method: str):
-        for module in self.modules:
+        for module in self.enabled_modules():
             moduleName = module.getModuleName()
             fc7name = module.getOpticalGroup().getBeBoard().getBoardName()
             filename = "{0}/SLDOCurve_Module_{1}_{2}_{3}.svg".format(
@@ -2151,7 +2166,7 @@ created by Ph2_ACF is empty."
         Returns a list of CSV filenames created.
         """
         csvfiles = []
-        for module in self.modules:
+        for module in self.enabled_modules():
             moduleName = module.getModuleName()
             for pin, name in pin_mapping.items():
                 if pin in trimbit_dict:
@@ -2207,9 +2222,14 @@ created by Ph2_ACF is empty."
         channelList = []
         for channel in measure:
             channelList.append(channel)
-        module_chan_map = dict(zip(self.modules,channelList))
+        modules_for_mapping = (
+            self.enabled_modules()
+            if len(channelList) == len(self.enabled_modules())
+            else self.modules
+        )
+        module_chan_map = dict(zip(modules_for_mapping, channelList))
 
-        for module in self.modules:
+        for module in self.enabled_modules():
             ogId = module.getOpticalGroup().getOpticalGroupID()
             beboardId = module.getOpticalGroup().getBeBoard().getBoardID()
             fc7name = module.getOpticalGroup().getBeBoard().getBoardName()
@@ -2305,7 +2325,7 @@ created by Ph2_ACF is empty."
             self.runTest()
 
     def SLDOScanFinished(self):
-        for module in self.modules:
+        for module in self.enabled_modules():
             ogId = module.getOpticalGroup().getOpticalGroupID()
             beboardId = module.getOpticalGroup().getBeBoard().getBoardID()
             fc7name = module.getOpticalGroup().getBeBoard().getBoardName()
@@ -2370,7 +2390,7 @@ created by Ph2_ACF is empty."
             self.runTest()
 
     def TrimbitScanFinished(self):
-        for module in self.modules:
+        for module in self.enabled_modules():
             ogId = module.getOpticalGroup().getOpticalGroupID()
             beboardId = module.getOpticalGroup().getBeBoard().getBoardID()
             fc7name = module.getOpticalGroup().getBeBoard().getBoardName()
@@ -2509,10 +2529,12 @@ created by Ph2_ACF is empty."
                 self.starttime = None
 
             for row in range(self.force_continue_window.table.rowCount()):
-                if not self.force_continue_window.table.item(row, 1).checkState():
-                    self.statuses[
-                        self.force_continue_window.table.item(row, 0).text()
-                    ] = "0"
+                module_name = self.force_continue_window.table.item(row, 0).text()
+                enabled = (
+                    self.force_continue_window.table.item(row, 1).checkState()
+                    == Qt.Checked
+                )
+                self.statuses[module_name] = "1" if enabled else "0"
 
             event.accept()
 
@@ -2636,15 +2658,13 @@ created by Ph2_ACF is empty."
                 + "const_cast<int*>(std::array<int, 4>{{{0}, {1}, {2}, {3}}}.data()))"
             )
 
-        for beboard in self.firmware:
-            boardID = beboard.getBoardID()
-            for OG in beboard.getAllOpticalGroups().values():
-                ogID = OG.getOpticalGroupID()
-                for module in OG.getAllModules().values():
-                    hybridID = module.getFMCPort()
-                    for chipID in module.getEnabledChips().keys():
-                        commands.append(
-                            command_template.format(boardID, ogID, hybridID, chipID)
-                        )
+        for module in self.enabled_modules():
+            ogId = module.getOpticalGroup().getOpticalGroupID()
+            boardId = module.getOpticalGroup().getBeBoard().getBoardID()
+            hybridId = module.getFMCPort()
+            for chipID in module.getEnabledChips().keys():
+                commands.append(
+                    command_template.format(boardId, ogId, hybridId, chipID)
+                )
         executeCommandSequence(commands)
     


### PR DESCRIPTION
## Description
The retry button in force continue dialog box now will appropriately retry the enabled modules.

## Checklist
Before submitting this PR, please ensure the following:

- [X] I am using the **correct branches/versions** of all submodules.
- [X] I have successfully **launched the Simplified GUI**.
- [X] I have successfully **run a test in the Simplified GUI**.
- [X] I have successfully **run a test in the Expert GUI**.

## Related Issues
Fixes #669 

## Changes Made
Added functionality to the enabled/disabled modules
Need to now track the run processes as this will change depending on number of enabled modules
handle_retry now is functional and just copy paste of normal test run process accounting for enabled modules
handle_continue also now will respond to enabled/disabled modules

## Testing
Tested on RH0108, RH0111 with RH0108 data disconnected
