### PR TITLE
Migrating from purdue to CMS database

### DIFF
--- a/Gui/GUIutils/guiUtils.py
+++ b/Gui/GUIutils/guiUtils.py
@@ -473,6 +473,19 @@ def GenerateXMLConfig(BeBoard, testName, outputDir, txt_files:dict, **arg):
                 chip_settings = FESettings_Dict[testName][registerKey].copy()
                 chip_settings['VREF_ADC'] = chip.getVREF()
                 chip_settings['INJ_CAP'] = chip.getCINJ()
+                chip_settings['DAC_PREAMP_L_LIN'] = chip.getDAC_PREAMP_L_LIN()
+                chip_settings['DAC_PREAMP_R_LIN'] = chip.getDAC_PREAMP_R_LIN()
+                chip_settings['DAC_PREAMP_TL_LIN'] = chip.getDAC_PREAMP_TL_LIN()
+                chip_settings['DAC_PREAMP_TR_LIN'] = chip.getDAC_PREAMP_TR_LIN()
+                chip_settings['DAC_PREAMP_T_LIN'] = chip.getDAC_PREAMP_T_LIN()
+                chip_settings['DAC_PREAMP_M_LIN'] = chip.getDAC_PREAMP_M_LIN()
+                chip_settings['DAC_REF_KRUM_LIN'] = chip.getDAC_REF_KRUM_LIN()
+                chip_settings['DAC_COMP_LIN'] = chip.getDAC_COMP_LIN()
+                chip_settings['DAC_COMP_TA_LIN'] = chip.getDAC_COMP_TA_LIN()
+                chip_settings['DAC_LDAC_LIN'] = chip.getDAC_LDAC_LIN()
+                chip_settings['ADC_OFFSET_VOLT'] = chip.getADC_OFFSET_VOLT()
+                chip_settings['ADC_MAXIMUM_VOLT'] = chip.getADC_MAXIMUM_VOLT()
+
                 FEChip.ConfigureFE(chip_settings)
             
                 if testName in FELaneConfig_Dict:

--- a/Gui/GUIutils/settings.py
+++ b/Gui/GUIutils/settings.py
@@ -117,6 +117,7 @@ ModuleLaneMap_Dict["HDIv2"] = copy.deepcopy(ModuleLaneMap)
 
 ModuleLaneMap_Dict["HDIv2"]["TFPX CROC 1x2"] = {"3": "12", "1": "13"}
 
+
 ChipMap = {
     "TFPX CROC 1x2": {
         "VDDD_B": "13",

--- a/Gui/QtGUIutils/QtApplication.py
+++ b/Gui/QtGUIutils/QtApplication.py
@@ -373,7 +373,7 @@ class QtApplication(QWidget):
             self.operator_name_first = data["name_first"]
             self.operator_name = data["name_first"] + " " + data["name_last"]
             self.panthera_connected = True
-            self.purdue_connected = self.checkPurdueConnection()
+            self.purdue_connected = self.checkDatabaseConnection()
 
             if (
                 data["privilege"] in ["Leader", "Conductor", "Admin", "Shifter"]
@@ -406,7 +406,7 @@ class QtApplication(QWidget):
             self.operator_name = "Local User"
             self.operator_name_first = "Local User"
             self.panthera_connected = False
-            self.purdue_connected = self.checkPurdueConnection()
+            self.purdue_connected = self.checkDatabaseConnection()
 
             self.destroyLogin()
             if self.expertMode:
@@ -418,12 +418,12 @@ class QtApplication(QWidget):
                 logger.debug("Entering Simplified GUI")
                 self.createSimplifiedMain()
 
-    def checkPurdueConnection(self):
+    def checkDatabaseConnection(self):
         status = False
         message = ""
         try:
             response = requests.get(
-                "https://www.physics.purdue.edu/cmsfpix/Phase2_Test/w.php?sn="
+                "https://cms-it-modules-registry.web.cern.ch/"
             )
             status = response.status_code == 200
             if not status:
@@ -438,7 +438,7 @@ class QtApplication(QWidget):
             msg.information(
                 None,
                 "Error",
-                f"There was an issue connecting to the Purdue database, please check your internet connection.\nMessage: {message}",
+                f"There was an issue connecting to the CMS database, please check your internet connection.\nMessage: {message}",
                 QMessageBox.Ok,
             )
         return status

--- a/Gui/python/CustomizedWidget.py
+++ b/Gui/python/CustomizedWidget.py
@@ -20,6 +20,7 @@ import requests
 from lxml import etree
 import re
 import traceback
+import requests
 
 from icicle.icicle.instrument_cluster import DummyInstrument
 import Gui.siteSettings as site_settings
@@ -257,8 +258,6 @@ class ChipBox(QWidget):
 
         self.IREF = IREF
         chip_iref_db[str(pChipID)] = str(IREF)  # Store as string for easy comparison
-        print(f"chip dict: {chip_iref_db}")
-        print(f"Module Chip ID: {pChipID}, IREF: {self.IREF}")
 
         if not self.ChipVDDDEdit.text():
             logger.debug("no VDDD text")
@@ -358,51 +357,81 @@ class ChipBox(QWidget):
         ChipStatus = ChipCheckBox.isChecked()
         return ChipStatus
 
+    def fetchNameLabel(self, moduleName): # Step 1: get the name label and module type (dual or quad)
+        registries = {
+            "quad": "https://cms-it-modules-registry.web.cern.ch/IT_Quad_Module.json",
+            "dual": "https://cms-it-modules-registry.web.cern.ch/IT_Double_Module.json",
+        }
+        moduleName_clean = moduleName.strip().upper() if moduleName else ""
+        for moduleType, url in registries.items():
+            try:
+                resp = requests.get(url, timeout=5)
+                resp.raise_for_status()
+                registry = resp.json()
+            except Exception as e:
+                logger.warning(f"Error loading {moduleType} registry from {url}: {e}")
+                continue
+
+
+            for entry in registry:
+                serial = (entry.get("SERIAL_NUMBER") or "").strip().upper()
+                if serial == moduleName_clean:
+                    name_label = entry.get("NAME_LABEL")
+                    logger.debug(
+                        f"found module {moduleName} in {moduleType} registry with name label {name_label}"
+                    )
+                    print(f"found module {moduleName} in {moduleType} registry with name label {name_label}")
+                    return name_label, moduleType
+
+
     def fetchHDIVersionFromDB(self, moduleName):
-        URL = f"https://www.physics.purdue.edu/cmsfpix/Phase2_Test/w.php?sn={moduleName}"
-        response = requests.get(URL)
-        html_content = response.text
-        match = re.search(r"Version\s*=\s*(.+)", html_content)
-        if match:
-            hdiversion = match.group(1).strip()
-        else:
-            print("Warning: HDI version not found for module.  Using default value of 1.")
-            hdiversion = "1"
-        return hdiversion
+        name_label, moduleType = self.fetchNameLabel(moduleName)
+        URL = f"https://cms-it-modules-registry.web.cern.ch/{name_label}.json"
+
+        try:
+            response = requests.get(URL)
+            response.raise_for_status()
+            data = response.json()
+
+            for entry in data.get("bare_module_data", []):
+                version = entry.get("VERSION")
+                if version is not None:
+                   return str(version).strip()
+
+            print(f"Warning: HDI version not found for {name_label}. Using default value of 1.")
+            return "1"
+
+        except requests.RequestException as e:
+            print(f"Warning: Could not fetch JSON for {name_label} ({e}). Using default value of 1.")
+            return "1"
+
+        except ValueError as e:
+            print(f"Warning: JSON parsing error for {name_label} ({e}). Using default value of 1.")
+            return "1"
+        
 
     ## This function returns a list of dictionaries.  Each element of the list is a chip dictinary.
-    ## For example, chipdata[0]['EFUSE'] is the efuse ID of thehttps://www.physics.purdue.edu/cmsfpix/Phase2_Test/w.php?sn={moduleName} first chip
     def fetchChipDataFromDB(self, moduleName):
+        name_label, moduleType = self.fetchNameLabel(moduleName)
         try:
-            URL = f"https://www.physics.purdue.edu/cmsfpix/Phase2_Test/w.php?sn={moduleName}"
+            URL = f"https://cms-it-modules-registry.web.cern.ch/{name_label}.json"
             response = requests.get(URL)
+            data = response.json()
 
-            parser = etree.HTMLParser()
-            tree = etree.fromstring(response.content, parser)
-            chip_table = tree.xpath("//body/table")[0]
-            # chipsitemap = {}
-            # chipsitemap['U1A'] = '12'
-            # chipsitemap['U1B'] = '13'
-            # chipsitemap['U1C'] = '14'
-            # chipsitemap['U1D'] = '15'
-            chipidmap = {}
-            chipidmap["0"] = "12"
-            chipidmap["1"] = "13"
-            chipidmap["2"] = "14"
-            chipidmap["3"] = "15"
+            chipidmap = {"0": "12", "1": "13", "2": "14", "3": "15"}
 
-            chipdatalist = []
-            for row in chip_table:
-                elementdata = []
-                for element in row:
-                    elementdata.append(element.text)
-                chipdatalist.append(elementdata)
-            chipdatadicts = [
-                dict(zip(chipdatalist[0], values)) for values in chipdatalist[1:]
-            ]
+            chipdatadicts = [entry for entry in data["bare_module_data"] if entry["KIND_OF_PART"] == "CROC Chip"]
+
             chipdata = {}
             for i, chip in enumerate(chipdatadicts):
-                chipdata[chipidmap[str(i)]] = chip
+                chipdata[chipidmap[str(i)]] = {
+                "VDDA": str(chip.get("VDDA_TRIM_CODE", "0")),
+                "VDDD": str(chip.get("VDDD_TRIM_CODE", "0")),
+                "IREF": str(chip.get("IREF_A", "0")),
+                "EFUSE": str(chip.get("EFUSE_CODE", "0")),
+                "VREF": str(chip.get("VREF_ADC_V", "0")),
+                "CINJ": str(chip.get("INJ_CAPACIT_F", "0")),
+                }
             return chipdata
 
         except requests.exceptions.RequestException as req_err:
@@ -411,7 +440,7 @@ class ChipBox(QWidget):
             msg.information(
                 None,
                 "Error",
-                f"There was an issue connecting to the Purdue database.\nMessage: {repr(req_err)}",
+                f"There was an issue connecting to the database.\nMessage: {repr(req_err)}",
                 QMessageBox.Ok,
             )
             logger.error(traceback.format_exc())
@@ -427,7 +456,7 @@ class ChipBox(QWidget):
             msg.information(
                 None,
                 "Error",
-                f"Could not find {moduleName} in the database, using default values.",
+                f"Could not find {name_label} in the database, using default values.",
                 QMessageBox.Ok,
             )
             logger.error(traceback.format_exc())
@@ -437,7 +466,7 @@ class ChipBox(QWidget):
         except Exception as e:
             # other issue
             logger.error(
-                f"Some error occurred while querying the Purdue DB for VDDD/VDDA trim values. \nError: {repr(e)}"
+                f"Some error occurred while querying the DB for VDDD/VDDA trim values. \nError: {repr(e)}"
             )
             logger.error(traceback.format_exc())
             self.master.purdue_connected = False
@@ -447,30 +476,40 @@ class ChipBox(QWidget):
             return None
 
     def fetchTrimFromDB(self, moduleName):
+        name_label, moduleType = self.fetchNameLabel(moduleName)
         try:
-            URL = f"https://www.physics.purdue.edu/cmsfpix/Phase2_Test/w.php?sn={moduleName}"
+            URL = f"https://cms-it-modules-registry.web.cern.ch/{name_label}.json"
 
             response = requests.get(URL)
+            data_json = response.json()
 
-            parser = etree.HTMLParser()
-            tree = etree.fromstring(response.content, parser)
-            chip_table = tree.xpath("//body/table")[0]
+            #chipidmap = {"0": "12", "1": "13", "2": "14", "3": "15"}## is this right?
+            chipidmap = {"12": "0", "13": "1", "14": "2", "15": "3"}
+            data={}
 
-            values = []
-            for row in chip_table[1:]:
-                for element in row:
-                    if element.text and element.text.startswith("U1"):
-                        values.append([])
+            for entry in data_json["bare_module_data"]:
+                if entry["KIND_OF_PART"] == "CROC Chip":
+                    slot = str(entry["ACROC_SLOT"])
 
-                    elif element.text and element.text.isdigit():
-                        values[-1].append(element.text)
+                    data[chipidmap[slot]] = {
+                        "VDDD": str(entry["VDDD_TRIM_CODE"]),
+                        "VDDA": str(entry["VDDA_TRIM_CODE"]),
+                        "IREF": str(entry["IREF_A"]),
+                        "EFUSE": str(entry["EFUSE_CODE"]),
+                        "VREF": str(entry["VREF_ADC_V"]),
+                        "CINJ": str(entry["INJ_CAPACIT_F"]),
+                    }
 
-            data = {}
-            for i in range(len(values)):
-                data[str(i + 12)] = {
-                    "VDDD": values[i][1],
-                    "VDDA": values[i][2],
-                }
+            for chipID in ["12", "13", "14", "15"]:
+                if chipID not in data:
+                    data[chipID] = {
+                        "VDDD": "0",
+                        "VDDA": "0",
+                        "IREF": "0",
+                        "EFUSE": "0",
+                        "VREF": "0",
+                        "CINJ": "0",
+                    }
 
             return data
         except requests.exceptions.RequestException as req_err:
@@ -479,7 +518,7 @@ class ChipBox(QWidget):
             msg.information(
                 None,
                 "Error",
-                f"There was an issue connecting to the Purdue database.\nMessage: {repr(req_err)}",
+                f"There was an issue connecting to the database.\nMessage: {repr(req_err)}",
                 QMessageBox.Ok,
             )
             logger.error(traceback.format_exc())
@@ -505,7 +544,7 @@ class ChipBox(QWidget):
         except Exception as e:
             # other issue
             logger.error(
-                f"Some error occurred while querying the Purdue DB for VDDD/VDDA trim values. \nError: {repr(e)}"
+                f"Some error occurred while querying the DB for VDDD/VDDA trim values. \nError: {repr(e)}"
             )
             logger.error(traceback.format_exc())
             self.master.purdue_connected = False
@@ -664,55 +703,72 @@ class BeBoardBox(QWidget):
             self.updateList()
 
     def fetchModuleTypeDB(self, moduleName):
-        if not self.master.purdue_connected:
-            return None
+
         try:
-            URL = f"https://www.physics.purdue.edu/cmsfpix/Phase2_Test/w.php?sn={moduleName}"
+            registries = {
+                "quad": "https://cms-it-modules-registry.web.cern.ch/IT_Quad_Module.json",
+                "dual": "https://cms-it-modules-registry.web.cern.ch/IT_Double_Module.json",
+            }
 
-            response = requests.get(URL)
+            moduleName_clean = moduleName.strip().upper() if moduleName else ""
+            name_label = None
+            moduleType = None
 
-            moduletype, moduleversion = None, None
-            res = str(response.content).split("\\n")
-            for i in res:
-                if i.startswith("<br>Part = "):
-                    moduletype = i.split("<br>Part = ")[1]
-                elif i.startswith("<br>Version = "):
-                    moduleversion = i.split("<br>Version = ")[1]
+            for mtype, url in registries.items():
+                try:
+                    resp = requests.get(url, timeout=5)
+                    resp.raise_for_status()
+                    registry = resp.json()
+                except Exception as e:
+                    logger.warning(f"Could not load registry {url}: {e}")
+                    continue
 
-            if moduletype.startswith("croc_1x2"):
-                moduletype = "TFPX CROC 1x2"
-            elif moduletype.startswith("croc_2x2"):
-                moduletype = "TFPX CROC Quad"
+                for entry in registry:
+                    serial = (entry.get("SERIAL_NUMBER") or "").strip().upper()
+                    if serial == moduleName_clean:
+                        name_label = entry.get("NAME_LABEL")
+                        moduleType = mtype
+                        break
+                if name_label:
+                    break
 
-            if moduletype == "" or moduleversion == "":
+            if not name_label:
                 msg = QMessageBox()
                 msg.information(
                     None,
                     "Error",
-                    f"Could not find {moduleName} in the database.",
+                    f"Could not find {moduleName} in the module registries.",
                     QMessageBox.Ok,
                 )
                 return None
-            else:
-                return {"type": moduletype, "HDIversion": f"{moduleversion}"}
-        except requests.exceptions.RequestException as req_err:
-            # some sort of connection issue, alert user
-            msg = QMessageBox()
-            msg.information(
-                None,
-                "Error",
-                f"There was an issue connecting to the Purdue database.\nMessage: {repr(req_err)}",
-                QMessageBox.Ok,
-            )
-            logger.error(traceback.format_exc())
 
-            self.master.purdue_connected = False
-            return None
-        except Exception as e:
-            # other issue
-            logger.error(
-                f"Some error occurred while querying the Purdue DB for module type. \nError: {repr(e)}"
-            )
+            # Fetch module JSON to determine HDI/version info
+            try:
+                url = f"https://cms-it-modules-registry.web.cern.ch/{name_label}.json"
+                resp = requests.get(url, timeout=5)
+                resp.raise_for_status()
+                data = resp.json()
+                moduleversion = None
+                for entry in data.get("bare_module_data", []):
+                    version = entry.get("VERSION")
+                    if version is not None:
+                        moduleversion = str(version).strip()
+                        break
+                if moduleversion is None:
+                    moduleversion = "1"
+            except Exception as e:
+                logger.warning(f"Could not fetch module JSON for {name_label}: {e}")
+                moduleversion = "1"
+
+            if moduleType == "dual":
+                moduletype = "TFPX CROC 1x2"
+            elif moduleType == "quad":
+                moduletype = "TFPX CROC Quad"
+            else:
+                moduletype = ""
+
+            return {"type": moduletype, "HDIversion": f"{moduleversion}"}
+        except Exception:
             logger.error(traceback.format_exc())
             self.master.purdue_connected = False
             return None
@@ -1161,55 +1217,72 @@ class SimpleBeBoardBox(QWidget):
         return self.FilledModuleList
 
     def fetchModuleTypeDB(self, moduleName):
-        if not self.master.purdue_connected:
-            return None
+
         try:
-            URL = f"https://www.physics.purdue.edu/cmsfpix/Phase2_Test/w.php?sn={moduleName}"
+            registries = {
+                "quad": "https://cms-it-modules-registry.web.cern.ch/IT_Quad_Module.json",
+                "dual": "https://cms-it-modules-registry.web.cern.ch/IT_Double_Module.json",
+            }
 
-            response = requests.get(URL)
+            moduleName_clean = moduleName.strip().upper() if moduleName else ""
+            name_label = None
+            moduleType = None
 
-            moduletype, moduleversion = None, None
-            res = str(response.content).split("\\n")
-            for i in res:
-                if i.startswith("<br>Part = "):
-                    moduletype = i.split("<br>Part = ")[1]
-                elif i.startswith("<br>Version = "):
-                    moduleversion = i.split("<br>Version = ")[1]
+            for mtype, url in registries.items():
+                try:
+                    resp = requests.get(url, timeout=5)
+                    resp.raise_for_status()
+                    registry = resp.json()
+                except Exception as e:
+                    logger.warning(f"Could not load registry {url}: {e}")
+                    continue
 
-            if moduletype.startswith("croc_1x2"):
-                moduletype = "TFPX CROC 1x2"
-            elif moduletype.startswith("croc_2x2"):
-                moduletype = "TFPX CROC Quad"
+                for entry in registry:
+                    serial = (entry.get("SERIAL_NUMBER") or "").strip().upper()
+                    if serial == moduleName_clean:
+                        name_label = entry.get("NAME_LABEL")
+                        moduleType = mtype
+                        break
+                if name_label:
+                    break
 
-            if moduletype == "" or moduleversion == "":
+            if not name_label:
                 msg = QMessageBox()
                 msg.information(
                     None,
                     "Error",
-                    f"Could not find {moduleName} in the database.",
+                    f"Could not find {moduleName} in the module registries.",
                     QMessageBox.Ok,
                 )
                 return None
-            else:
-                return {"type": moduletype, "HDIversion": f"{moduleversion}"}
-        except requests.exceptions.RequestException as req_err:
-            # some sort of connection issue, alert user
-            msg = QMessageBox()
-            msg.information(
-                None,
-                "Error",
-                f"There was an issue connecting to the Purdue database.\nMessage: {repr(req_err)}",
-                QMessageBox.Ok,
-            )
-            logger.error(traceback.format_exc())
 
-            self.master.purdue_connected = False
-            return None
-        except Exception as e:
-            # other issue
-            logger.error(
-                f"Some error occurred while querying the Purdue DB for module type. \nError: {repr(e)}"
-            )
+            # Fetch module JSON to determine HDI/version info
+            try:
+                url = f"https://cms-it-modules-registry.web.cern.ch/{name_label}.json"
+                resp = requests.get(url, timeout=5)
+                resp.raise_for_status()
+                data = resp.json()
+                moduleversion = None
+                for entry in data.get("bare_module_data", []):
+                    version = entry.get("VERSION")
+                    if version is not None:
+                        moduleversion = str(version).strip()
+                        break
+                if moduleversion is None:
+                    moduleversion = "1"
+            except Exception as e:
+                logger.warning(f"Could not fetch module JSON for {name_label}: {e}")
+                moduleversion = "1"
+
+            if moduleType == "dual":
+                moduletype = "TFPX CROC 1x2"
+            elif moduleType == "quad":
+                moduletype = "TFPX CROC Quad"
+            else:
+                moduletype = ""
+
+            return {"type": moduletype, "HDIversion": f"{moduleversion}"}
+        except Exception:
             logger.error(traceback.format_exc())
             self.master.purdue_connected = False
             return None
@@ -1272,7 +1345,7 @@ class SimpleBeBoardBox(QWidget):
                 OpticalGroup
             )  # Ignore this line, see explanation in Firmware.py
 
-            # Fetch the VDDD/VDDA trim values from the Purdue DB, make a ChipBox due to built in error handling
+            # Fetch the VDDD/VDDA trim values from the DB, make a ChipBox due to built in error handling
             chipBox = ChipBox(
                 self.master,
                 module.getType(module.getSerialNumber()),

--- a/Gui/python/CustomizedWidget.py
+++ b/Gui/python/CustomizedWidget.py
@@ -396,7 +396,18 @@ class ChipBox(QWidget):
             for entry in data.get("bare_module_data", []):
                 version = entry.get("VERSION")
                 if version is not None:
-                   return str(version).strip()
+                    try:
+                        vstr = str(version).strip()
+                        if "." in vstr:
+                            vstr = str(int(float(vstr)))
+                        else:
+                            try:
+                                vstr = str(int(vstr))
+                            except Exception:
+                                pass
+                        return vstr
+                    except Exception:
+                        return str(version).strip()
 
             print(f"Warning: HDI version not found for {name_label}. Using default value of 1.")
             return "1"
@@ -767,7 +778,19 @@ class BeBoardBox(QWidget):
             else:
                 moduletype = ""
 
-            return {"type": moduletype, "HDIversion": f"{moduleversion}"}
+            try:
+                mv = str(moduleversion).strip()
+                if "." in mv:
+                    mv = str(int(float(mv)))
+                else:
+                    try:
+                        mv = str(int(mv))
+                    except Exception:
+                        pass
+            except Exception:
+                mv = str(moduleversion)
+
+            return {"type": moduletype, "HDIversion": f"{mv}"}
         except Exception:
             logger.error(traceback.format_exc())
             self.master.purdue_connected = False

--- a/Gui/python/CustomizedWidget.py
+++ b/Gui/python/CustomizedWidget.py
@@ -427,10 +427,10 @@ class ChipBox(QWidget):
                 chipdata[chipidmap[str(i)]] = {
                 "VDDA": str(chip.get("VDDA_TRIM_CODE", "0")),
                 "VDDD": str(chip.get("VDDD_TRIM_CODE", "0")),
-                "IREF": str(chip.get("IREF_A", "0")),
+                "IREF": str(chip.get("IREF_TRIM_CODE", "0")),
                 "EFUSE": str(chip.get("EFUSE_CODE", "0")),
                 "VREF": str(chip.get("VREF_ADC_V", "0")),
-                "CINJ": str(chip.get("INJ_CAPACIT_F", "0")),
+                "CINJ": str(chip.get("INJ_CAPACIT_F", "0")), ## Unit conversion here
                 }
             return chipdata
 

--- a/Gui/python/CustomizedWidget.py
+++ b/Gui/python/CustomizedWidget.py
@@ -429,7 +429,10 @@ class ChipBox(QWidget):
             response = requests.get(URL)
             data = response.json()
 
-            chipidmap = {"0": "12", "1": "13", "2": "14", "3": "15"}
+            if moduleType == "quad":
+                chipidmap = {"0": "12", "1": "13", "2": "14", "3": "15"}
+            else:
+                chipidmap = {"1": "12", "0": "13"}
 
             chipdatadicts = [entry for entry in data["bare_module_data"] if entry["KIND_OF_PART"] == "CROC Chip"]
 
@@ -441,7 +444,7 @@ class ChipBox(QWidget):
                 "IREF": str(chip.get("IREF_TRIM_CODE", "0")),
                 "EFUSE": str(chip.get("EFUSE_CODE", "0")),
                 "VREF": str(chip.get("VREF_ADC_V", "0")),
-                "CINJ": str(chip.get("INJ_CAPACIT_F", "0")), ## Unit conversion here
+                "CINJ": str(chip.get("INJ_CAPACIT_F", "0")), ## Unit conversion needed here
                 }
             return chipdata
 
@@ -494,8 +497,12 @@ class ChipBox(QWidget):
             response = requests.get(URL)
             data_json = response.json()
 
-            #chipidmap = {"0": "12", "1": "13", "2": "14", "3": "15"}## is this right?
-            chipidmap = {"12": "0", "13": "1", "14": "2", "15": "3"}
+
+            if moduleType == "quad":
+                chipidmap = {"0": "12", "1": "13", "2": "14", "3": "15"}
+            else:
+                chipidmap = {"1": "12", "0": "13"}
+
             data={}
 
             for entry in data_json["bare_module_data"]:
@@ -505,10 +512,10 @@ class ChipBox(QWidget):
                     data[chipidmap[slot]] = {
                         "VDDD": str(entry["VDDD_TRIM_CODE"]),
                         "VDDA": str(entry["VDDA_TRIM_CODE"]),
-                        "IREF": str(entry["IREF_A"]),
+                        "IREF": str(entry["IREF_TRIM_CODE"]),
                         "EFUSE": str(entry["EFUSE_CODE"]),
                         "VREF": str(entry["VREF_ADC_V"]),
-                        "CINJ": str(entry["INJ_CAPACIT_F"]),
+                        "CINJ": str(entry["INJ_CAPACIT_F"]), ## Unit conversion needed here
                     }
 
             for chipID in ["12", "13", "14", "15"]:

--- a/Gui/python/CustomizedWidget.py
+++ b/Gui/python/CustomizedWidget.py
@@ -346,6 +346,54 @@ class ChipBox(QWidget):
         CINJthing = self.chipData[pChipID]["CINJ"]
         return CINJthing
 
+    def getDAC_PREAMP_L_LIN(self, pChipID):
+        DAC_PREAMP_L_LINthing = self.chipData[pChipID]["DAC_PREAMP_L_LIN"]
+        return DAC_PREAMP_L_LINthing
+
+    def getDAC_PREAMP_R_LIN(self, pChipID):
+        DAC_PREAMP_R_LINthing = self.chipData[pChipID]["DAC_PREAMP_R_LIN"]
+        return DAC_PREAMP_R_LINthing
+
+    def getDAC_PREAMP_TL_LIN(self, pChipID):
+        DAC_PREAMP_TL_LINthing = self.chipData[pChipID]["DAC_PREAMP_TL_LIN"]
+        return DAC_PREAMP_TL_LINthing
+
+    def getDAC_PREAMP_TR_LIN(self, pChipID):
+        DAC_PREAMP_TR_LINthing = self.chipData[pChipID]["DAC_PREAMP_TR_LIN"]
+        return DAC_PREAMP_TR_LINthing
+
+    def getDAC_PREAMP_T_LIN(self, pChipID):
+        DAC_PREAMP_T_LINthing = self.chipData[pChipID]["DAC_PREAMP_T_LIN"]
+        return DAC_PREAMP_T_LINthing
+
+    def getDAC_PREAMP_M_LIN(self, pChipID):
+        DAC_PREAMP_M_LINthing = self.chipData[pChipID]["DAC_PREAMP_M_LIN"]
+        return DAC_PREAMP_M_LINthing
+
+    def getDAC_REF_KRUM_LIN(self, pChipID):
+        DAC_REF_KRUM_LINthing = self.chipData[pChipID]["DAC_REF_KRUM_LIN"]
+        return DAC_REF_KRUM_LINthing
+
+    def getDAC_COMP_LIN(self, pChipID):
+        DAC_COMP_LINthing = self.chipData[pChipID]["DAC_COMP_LIN"]
+        return DAC_COMP_LINthing
+    
+    def getDAC_COMP_TA_LIN(self, pChipID):
+        DAC_COMP_TA_LINthing = self.chipData[pChipID]["DAC_COMP_TA_LIN"]
+        return DAC_COMP_TA_LINthing
+
+    def getDAC_LDAC_LIN(self, pChipID):
+        DAC_LDAC_LINthing = self.chipData[pChipID]["DAC_LDAC_LIN"]
+        return DAC_LDAC_LINthing
+    
+    def getADC_OFFSET_VOLT(self, pChipID):
+        ADC_OFFSET_VOLTthing = self.chipData[pChipID]["ADC_OFFSET_VOLT"]
+        return ADC_OFFSET_VOLTthing
+
+    def getADC_MAXIMUM_VOLT(self, pChipID):
+        ADC_MAXIMUM_VOLTthing = self.chipData[pChipID]["ADC_MAXIMUM_VOLT"]
+        return ADC_MAXIMUM_VOLTthing
+
     def getChipData(self):
         return self.chipData
 
@@ -437,6 +485,7 @@ class ChipBox(QWidget):
             chipdatadicts = [entry for entry in data["bare_module_data"] if entry["KIND_OF_PART"] == "CROC Chip"]
 
             chipdata = {}
+
             for i, chip in enumerate(chipdatadicts):
                 chipdata[chipidmap[str(i)]] = {
                 "VDDA": str(chip.get("VDDA_TRIM_CODE", "0")),
@@ -444,8 +493,21 @@ class ChipBox(QWidget):
                 "IREF": str(chip.get("IREF_TRIM_CODE", "0")),
                 "EFUSE": str(chip.get("EFUSE_CODE", "0")),
                 "VREF": str(chip.get("VREF_ADC_V", "0")),
-                "CINJ": str(chip.get("INJ_CAPACIT_F", "0")), ## Unit conversion needed here
+                "CINJ": str(chip.get("INJ_CAPACIT_F", "0")),
+                "ADC_OFFSET_VOLT": str(1e4*float(chip.get("ADC_OFF_V", "0"))),
+                "ADC_MAXIMUM_VOLT": str(1e3*(4096*float(chip.get("ADC_SLO", "0"))+float(chip.get("ADC_OFF_V", "0")))),
+                "DAC_PREAMP_L_LIN": str(chip.get("probe_data").get("DAC_PREAMP_L_LIN", "0")),
+                "DAC_PREAMP_R_LIN": str(chip.get("probe_data").get("DAC_PREAMP_R_LIN", "0")),
+                "DAC_PREAMP_TL_LIN": str(chip.get("probe_data").get("DAC_PREAMP_TL_LIN", "0")),
+                "DAC_PREAMP_TR_LIN": str(chip.get("probe_data").get("DAC_PREAMP_TR_LIN", "0")),
+                "DAC_PREAMP_T_LIN": str(chip.get("probe_data").get("DAC_PREAMP_T_LIN", "0")),
+                "DAC_PREAMP_M_LIN": str(chip.get("probe_data").get("DAC_PREAMP_M_LIN", "0")),
+                "DAC_REF_KRUM_LIN": str(chip.get("probe_data").get("DAC_REF_KRUM_LIN", "0")),
+                "DAC_COMP_LIN": str(chip.get("probe_data").get("DAC_COMP_LIN", "0")),
+                "DAC_COMP_TA_LIN": str(chip.get("probe_data").get("DAC_COMP_TA_LIN", "0")),
+                "DAC_LDAC_LIN": str(chip.get("probe_data").get("DAC_LDAC_LIN", "0")),
                 }
+            logger.info(f"Fetched chip data for {name_label}: {chipdata}")
             return chipdata
 
         except requests.exceptions.RequestException as req_err:
@@ -516,6 +578,18 @@ class ChipBox(QWidget):
                         "EFUSE": str(entry["EFUSE_CODE"]),
                         "VREF": str(entry["VREF_ADC_V"]),
                         "CINJ": str(entry["INJ_CAPACIT_F"]), ## Unit conversion needed here
+                        "ADC_OFFSET_VOLT": str(entry["ADC_OFF_V"]),
+                        "ADC_MAXIMUM_VOLT": str(entry["ADC_SLO"]),
+                        "DAC_PREAMP_L_LIN": str(entry["DAC_PREAMP_L_LIN"]),
+                        "DAC_PREAMP_R_LIN": str(entry["DAC_PREAMP_R_LIN"]),
+                        "DAC_PREAMP_TL_LIN": str(entry["DAC_PREAMP_TL_LIN"]),
+                        "DAC_PREAMP_TR_LIN": str(entry["DAC_PREAMP_TR_LIN"]),
+                        "DAC_PREAMP_T_LIN": str(entry["DAC_PREAMP_T_LIN"]),
+                        "DAC_PREAMP_M_LIN": str(entry["DAC_PREAMP_M_LIN"]),
+                        "DAC_REF_KRUM_LIN": str(entry["DAC_REF_KRUM_LIN"]),
+                        "DAC_COMP_LIN": str(entry["DAC_COMP_LIN"]),
+                        "DAC_COMP_TA_LIN": str(entry["DAC_COMP_TA_LIN"]),
+                        "DAC_LDAC_LIN": str(entry["DAC_LDAC_LIN"]),
                     }
 
             for chipID in ["12", "13", "14", "15"]:
@@ -527,6 +601,18 @@ class ChipBox(QWidget):
                         "EFUSE": "0",
                         "VREF": "0",
                         "CINJ": "0",
+                        "DAC_PREAMP_L_LIN": "0",
+                        "DAC_PREAMP_R_LIN": "0",
+                        "DAC_PREAMP_TL_LIN": "0",
+                        "DAC_PREAMP_TR_LIN": "0",
+                        "DAC_PREAMP_T_LIN": "0",
+                        "DAC_PREAMP_M_LIN": "0",
+                        "DAC_REF_KRUM_LIN": "0",
+                        "DAC_COMP_LIN": "0",
+                        "DAC_COMP_TA_LIN": "0",
+                        "DAC_LDAC_LIN": "0",
+                        "ADC_OFFSET_VOLT": "0",
+                        "ADC_MAXIMUM_VOLT": "0",
                     }
 
             return data
@@ -882,6 +968,43 @@ class BeBoardBox(QWidget):
                 Module.getChips()[chipID].setIREF(
                     self.ChipWidgetDict[module].getIREF(chipID)
                 )
+                Module.getChips()[chipID].setDAC_PREAMP_L_LIN(
+                    self.ChipWidgetDict[module].getDAC_PREAMP_L_LIN(chipID)
+                )
+                Module.getChips()[chipID].setDAC_PREAMP_R_LIN(
+                    self.ChipWidgetDict[module].getDAC_PREAMP_R_LIN(chipID)
+                )
+                Module.getChips()[chipID].setDAC_PREAMP_TL_LIN(
+                    self.ChipWidgetDict[module].getDAC_PREAMP_TL_LIN(chipID)
+                )
+                Module.getChips()[chipID].setDAC_PREAMP_TR_LIN(
+                    self.ChipWidgetDict[module].getDAC_PREAMP_TR_LIN(chipID)
+                )
+                Module.getChips()[chipID].setDAC_PREAMP_T_LIN(
+                    self.ChipWidgetDict[module].getDAC_PREAMP_T_LIN(chipID)
+                )
+                Module.getChips()[chipID].setDAC_PREAMP_M_LIN(
+                    self.ChipWidgetDict[module].getDAC_PREAMP_M_LIN(chipID)
+                )
+                Module.getChips()[chipID].setDAC_REF_KRUM_LIN(
+                    self.ChipWidgetDict[module].getDAC_REF_KRUM_LIN(chipID)
+                )
+                Module.getChips()[chipID].setDAC_COMP_LIN(
+                    self.ChipWidgetDict[module].getDAC_COMP_LIN(chipID)
+                )
+                Module.getChips()[chipID].setDAC_COMP_TA_LIN(
+                    self.ChipWidgetDict[module].getDAC_COMP_TA_LIN(chipID)
+                )
+                Module.getChips()[chipID].setDAC_LDAC_LIN(
+                    self.ChipWidgetDict[module].getDAC_LDAC_LIN(chipID)
+                )
+                Module.getChips()[chipID].setADC_MAXIMUM_VOLT(
+                    self.ChipWidgetDict[module].getADC_MAXIMUM_VOLT(chipID)
+                )
+                Module.getChips()[chipID].setADC_OFFSET_VOLT(
+                    self.ChipWidgetDict[module].getADC_OFFSET_VOLT(chipID)
+                )
+                
                 try:
                     vref_value = float(self.ChipWidgetDict[module].getVREF(chipID))
                 except Exception:
@@ -895,7 +1018,7 @@ class BeBoardBox(QWidget):
                 except Exception:
                     cinj_value = 8
                 Module.getChips()[chipID].setCINJ(
-                    (10 * cinj_value)
+                    (1e13 * cinj_value)
                 )
 
             # Add the QtModule object to the currently selected Optical Group
@@ -1049,7 +1172,7 @@ class SimpleModuleBox(QWidget):
         self.CableIDEdit.setText(str(laneId))
 
     def setHDIversion(self, hdiVersion: str):
-        self.HDIversion = hdiVersion
+        self.HDIversion = hdiVersion.split(".")[0]
 
     def getID(self):
         return self.CableIDEdit.text()
@@ -1391,7 +1514,19 @@ class SimpleBeBoardBox(QWidget):
                     Module.getChips()[chipID].setEfuseID(chipData[chipID]["EFUSE"])
                     Module.getChips()[chipID].setIREF(chipData[chipID]["IREF"])
                     Module.getChips()[chipID].setVREF(str(1000 * float(chipData[chipID]["VREF"])))
-                    Module.getChips()[chipID].setCINJ(str(10 * float(chipData[chipID]["CINJ"])))
+                    Module.getChips()[chipID].setCINJ(str(1e13 * float(chipData[chipID]["CINJ"])))
+                    Module.getChips()[chipID].setADC_OFFSET_VOLT(str(chipData[chipID]["ADC_OFFSET_VOLT"]))
+                    Module.getChips()[chipID].setADC_MAXIMUM_VOLT(str(chipData[chipID]["ADC_MAXIMUM_VOLT"]))
+                    Module.getChips()[chipID].setDAC_PREAMP_L_LIN(chipData[chipID]["DAC_PREAMP_L_LIN"])
+                    Module.getChips()[chipID].setDAC_PREAMP_R_LIN(chipData[chipID]["DAC_PREAMP_R_LIN"])
+                    Module.getChips()[chipID].setDAC_PREAMP_TL_LIN(chipData[chipID]["DAC_PREAMP_TL_LIN"])
+                    Module.getChips()[chipID].setDAC_PREAMP_TR_LIN(chipData[chipID]["DAC_PREAMP_TR_LIN"])
+                    Module.getChips()[chipID].setDAC_PREAMP_T_LIN(chipData[chipID]["DAC_PREAMP_T_LIN"])
+                    Module.getChips()[chipID].setDAC_PREAMP_M_LIN(chipData[chipID]["DAC_PREAMP_M_LIN"])
+                    Module.getChips()[chipID].setDAC_REF_KRUM_LIN(chipData[chipID]["DAC_REF_KRUM_LIN"])
+                    Module.getChips()[chipID].setDAC_COMP_LIN(chipData[chipID]["DAC_COMP_LIN"])
+                    Module.getChips()[chipID].setDAC_COMP_TA_LIN(chipData[chipID]["DAC_COMP_TA_LIN"])
+                    Module.getChips()[chipID].setDAC_LDAC_LIN(chipData[chipID]["DAC_LDAC_LIN"])
                     
             else:
                 print(

--- a/Gui/python/Firmware.py
+++ b/Gui/python/Firmware.py
@@ -15,6 +15,18 @@ class QtChip:
         chipVREF=800,
         chipIREF="",
         chipCINJ=80,
+        chipADC_OFFSET_VOLT=63,
+        chipADC_MAXIMUM_VOLT=839,
+        chipDAC_PREAMP_L_LIN=300,
+        chipDAC_PREAMP_R_LIN=300,
+        chipDAC_PREAMP_TL_LIN=300,
+        chipDAC_PREAMP_TR_LIN=300,
+        chipDAC_PREAMP_T_LIN=300,
+        chipDAC_PREAMP_M_LIN=300,
+        chipDAC_REF_KRUM_LIN=360,
+        chipDAC_COMP_LIN=110,
+        chipDAC_COMP_TA_LIN=110,
+        chipDAC_LDAC_LIN=140,
         chipStatus=True,
     ):
         self.__chipID = chipID
@@ -25,6 +37,18 @@ class QtChip:
         self.__chipVREF = chipVREF
         self.__chipIREF = chipIREF
         self.__chipCINJ = chipCINJ
+        self.__ADC_OFFSET_VOLT = chipADC_OFFSET_VOLT
+        self.__ADC_MAXIMUM_VOLT = chipADC_MAXIMUM_VOLT
+        self.__chipDAC_PREAMP_L_LIN = chipDAC_PREAMP_L_LIN
+        self.__chipDAC_PREAMP_R_LIN = chipDAC_PREAMP_R_LIN
+        self.__chipDAC_PREAMP_TL_LIN = chipDAC_PREAMP_TL_LIN
+        self.__chipDAC_PREAMP_TR_LIN = chipDAC_PREAMP_TR_LIN
+        self.__chipDAC_PREAMP_T_LIN = chipDAC_PREAMP_T_LIN
+        self.__chipDAC_PREAMP_M_LIN = chipDAC_PREAMP_M_LIN
+        self.__chipDAC_REF_KRUM_LIN = chipDAC_REF_KRUM_LIN
+        self.__chipDAC_COMP_LIN = chipDAC_COMP_LIN
+        self.__chipDAC_COMP_TA_LIN = chipDAC_COMP_TA_LIN
+        self.__chipDAC_LDAC_LIN = chipDAC_LDAC_LIN
         self.__chipStatus = chipStatus
 
     def setID(self, id: str):
@@ -71,9 +95,81 @@ class QtChip:
     
     def setCINJ(self, pCINJ: int):
         self.__chipCINJ = pCINJ
-    
+
     def getCINJ(self):
         return self.__chipCINJ
+
+    def setADC_OFFSET_VOLT(self, pADC_OFFSET_VOLT: int):
+        self.__ADC_OFFSET_VOLT = pADC_OFFSET_VOLT
+
+    def getADC_OFFSET_VOLT(self):
+        return self.__ADC_OFFSET_VOLT
+        
+    def setADC_MAXIMUM_VOLT(self, pADC_MAXIMUM_VOLT: int):
+        self.__ADC_MAXIMUM_VOLT = pADC_MAXIMUM_VOLT
+
+    def getADC_MAXIMUM_VOLT(self):
+        return self.__ADC_MAXIMUM_VOLT  
+
+    def setDAC_PREAMP_L_LIN(self, pDAC_PREAMP_L_LIN: int):
+        self.__chipDAC_PREAMP_L_LIN = pDAC_PREAMP_L_LIN
+
+    def getDAC_PREAMP_L_LIN(self):
+        return self.__chipDAC_PREAMP_L_LIN
+
+    def setDAC_PREAMP_R_LIN(self, pDAC_PREAMP_R_LIN: int):
+        self.__chipDAC_PREAMP_R_LIN = pDAC_PREAMP_R_LIN
+
+    def getDAC_PREAMP_R_LIN(self):
+        return self.__chipDAC_PREAMP_R_LIN
+
+    def setDAC_PREAMP_TL_LIN(self, pDAC_PREAMP_TL_LIN: int):
+        self.__chipDAC_PREAMP_TL_LIN = pDAC_PREAMP_TL_LIN
+
+    def getDAC_PREAMP_TL_LIN(self):
+        return self.__chipDAC_PREAMP_TL_LIN
+
+    def setDAC_PREAMP_TR_LIN(self, pDAC_PREAMP_TR_LIN: int):
+        self.__chipDAC_PREAMP_TR_LIN = pDAC_PREAMP_TR_LIN
+
+    def getDAC_PREAMP_TR_LIN(self):
+        return self.__chipDAC_PREAMP_TR_LIN
+
+    def setDAC_PREAMP_T_LIN(self, pDAC_PREAMP_T_LIN: int):
+        self.__chipDAC_PREAMP_T_LIN = pDAC_PREAMP_T_LIN
+
+    def getDAC_PREAMP_T_LIN(self):    
+        return self.__chipDAC_PREAMP_T_LIN
+
+    def setDAC_PREAMP_M_LIN(self, pDAC_PREAMP_M_LIN: int):
+        self.__chipDAC_PREAMP_M_LIN = pDAC_PREAMP_M_LIN
+
+    def getDAC_PREAMP_M_LIN(self):
+        return self.__chipDAC_PREAMP_M_LIN
+
+    def setDAC_REF_KRUM_LIN(self, pDAC_REF_KRUM_LIN: int):
+        self.__chipDAC_REF_KRUM_LIN = pDAC_REF_KRUM_LIN
+
+    def getDAC_REF_KRUM_LIN(self):
+        return self.__chipDAC_REF_KRUM_LIN
+
+    def setDAC_COMP_LIN(self, pDAC_COMP_LIN: int):
+        self.__chipDAC_COMP_LIN = pDAC_COMP_LIN
+
+    def getDAC_COMP_LIN(self):
+        return self.__chipDAC_COMP_LIN
+
+    def setDAC_COMP_TA_LIN(self, pDAC_COMP_TA_LIN: int):
+        self.__chipDAC_COMP_TA_LIN = pDAC_COMP_TA_LIN
+
+    def getDAC_COMP_TA_LIN(self):
+        return self.__chipDAC_COMP_TA_LIN
+
+    def setDAC_LDAC_LIN(self, pDAC_LDAC_LIN: int):
+        self.__chipDAC_LDAC_LIN = pDAC_LDAC_LIN
+
+    def getDAC_LDAC_LIN(self):
+        return self.__chipDAC_LDAC_LIN
 
     def setStatus(self, pStatus: bool):
         self.__chipStatus = pStatus
@@ -135,10 +231,10 @@ class QtModule:
         return self.__moduleVersion
     
     def getHDIVersion(self):
-        return self.__hdiVersion
+        return self.__hdiVersion.split(".")[0]
 
     def setHDIVersion(self, hdiVersion: str):
-        self.__hdiVersion = hdiVersion
+        self.__hdiVersion = hdiVersion.split(".")[0]
         
     def setFMCPort(self, FMCPort: str):
         self.__FMCPort = FMCPort
@@ -149,7 +245,7 @@ class QtModule:
     def __setupChips(self):
         self.__chipDict.clear()
 
-        for LaneID, ChipID in ModuleLaneMap_Dict["HDIv{0}".format(self.__hdiVersion)][self.__moduleType].items():
+        for LaneID, ChipID in ModuleLaneMap_Dict["HDIv{0}".format(self.__hdiVersion.split(".")[0])][self.__moduleType].items():
             FEChip = QtChip(
                 chipID=ChipID, chipLane=LaneID, chipVDDA=8, chipVDDD=8, chipStatus=True
             )


### PR DESCRIPTION
## Description
Trim values are now parsed from CMS database, rather than purdue database.

## Checklist
Before submitting this PR, please ensure the following:

- [x] I am using the **correct branches/versions** of all submodules.
- [x] I have successfully **launched the Simplified GUI**.
- [x] I have successfully **run a test in the Simplified GUI**.
- [x] I have successfully **run a test in the Expert GUI**.

## Related Issues
closes #666 

## Changes Made
Trim values are now pulled from the CMS database, not the purdue database in CustomizedWidget.py. Chipid mapping updated for Dual chips to fit the ACROC -> ChipID maps

## Testing
Changed CustomizedWidget.py to get trim values from the CMS database rather than purdue. First, we fetch the nameLabel, from the module serial number. then from the nameLabel, all the other needed data is gathered. 

## Additional Notes
<!-- Add any additional comments or context if needed. -->
