### PR TITLE
Warning bug

### DIFF
--- a/Gui/QtGUIutils/QtApplication.py
+++ b/Gui/QtGUIutils/QtApplication.py
@@ -28,7 +28,7 @@ from felis.felis_helpers import get_accountInfo
 from Gui.QtGUIutils.Loading import LoadingWheel, LoadingThread
 
 import Gui.siteSettings as site_settings
-from Gui.siteSettings import allow_test_without_fc7
+from Gui.siteSettings import UI_testing
 from Gui.GUIutils.FirmwareUtil import fwStatusParser, FwStatusCheck
 from Gui.QtGUIutils.QtRunWindow import QtRunWindow
 from Gui.QtGUIutils.LaudaApp import LaudaWidget
@@ -77,6 +77,7 @@ class QtApplication(QWidget):
         self.PYTHON_VERSION = str(sys.version).split(" ")[0]
         self.dimension = dimension
         self.available_visa_resources = pyvisa.ResourceManager("@py").list_resources()
+        self.ui_testing = UI_testing
 
         self.desired_devices = {"hv": 1, "lv": 1, "relay": 0, "multimeter": 0}
         self.connected_device_information = {
@@ -475,6 +476,11 @@ class QtApplication(QWidget):
         self.StatusList = [
             self.create_status_label("Panthera DB", self.panthera_connected),
         ]
+        if self.ui_testing and not site_settings.FC7List:
+            fw_name_label = QLabel("FC7 (UI only)")
+            fw_status_label = QLabel("UI Only")
+            fw_status_label.setStyleSheet("color: orange")
+            self.StatusList.append([fw_name_label, fw_status_label])
 
         try:
             for firmwareName, ipaddress in site_settings.FC7List.items():
@@ -502,6 +508,9 @@ class QtApplication(QWidget):
             if index == 0:
                 self.CheckButton = QPushButton("&Fw Check")
                 self.CheckButton.clicked.connect(self.checkFirmware)
+                if self.ui_testing:
+                    self.CheckButton.setDisabled(True)
+                    self.CheckButton.setToolTip("UI-only mode: firmware checks are disabled")
                 StatusLayout.addWidget(self.CheckButton, index, 0, 1, 1)
                 StatusLayout.addWidget(items[0], index, 1, 1, 1)
                 StatusLayout.addWidget(items[1], index, 2, 1, 2)
@@ -520,6 +529,11 @@ class QtApplication(QWidget):
                     UseButton.clicked.connect(self.checkFirmware)
                 UseButton.setCheckable(True)
                 self.UseButtons.append(UseButton)
+                if self.ui_testing:
+                    UseButton.setText("UI Only")
+                    UseButton.setDisabled(True)
+                    items[1].setText("UI Only")
+                    items[1].setStyleSheet("color: orange")
                 StatusLayout.addWidget(UseButton, index, 0, 1, 1)
                 StatusLayout.addWidget(items[0], index, 1, 1, 1)
                 StatusLayout.addWidget(items[1], index, 2, 1, 2)
@@ -557,6 +571,9 @@ class QtApplication(QWidget):
         self.DefaultButton = QPushButton("&Connect all devices")
         if site_settings.icicle_instrument_setup is None:
             self.DefaultButton.setEnabled(False)
+        if self.ui_testing:
+            self.DefaultButton.setEnabled(False)
+            self.DefaultButton.setToolTip("UI-only mode: hardware connections are disabled")
 
         self.Wheel = LoadingWheel()
 
@@ -603,6 +620,9 @@ class QtApplication(QWidget):
         else:
             self.HVPortName.setText("")
             self.HVDeviceName.setText("Manual HV Control")
+        if self.ui_testing:
+            self.HVPortName.setText("")
+            self.HVDeviceName.setText("UI Only")
 
         self.HVPowerStatusValue = QLabel()
         logger.debug("Setup HV")
@@ -647,6 +667,9 @@ class QtApplication(QWidget):
         else:
             self.LVPortName.setText("")
             self.LVDeviceName.setText("Manual LV Control")
+        if self.ui_testing:
+            self.LVPortName.setText("")
+            self.LVDeviceName.setText("UI Only")
 
         self.LVPowerLayout.addWidget(self.LVDeviceLabel, 0, 0, 1, 1)
         self.LVPowerLayout.addWidget(self.LVDeviceName, 0, 1, 1, 1)
@@ -697,6 +720,9 @@ class QtApplication(QWidget):
             else:
                 self.relay_device_name.setText("Manual Relay Control")
                 self.relay_board_port_name.setText("")
+            if self.ui_testing:
+                self.relay_device_name.setText("UI Only")
+                self.relay_board_port_name.setText("")
 
             self.relay_model_status = QLabel()
 
@@ -743,6 +769,9 @@ class QtApplication(QWidget):
                 self.multimeter_group.setDisabled(False)
             else:
                 self.multimeter_device_name.setText("Manual multimeter control")
+                self.multimeter_port_name.setText("")
+            if self.ui_testing:
+                self.multimeter_device_name.setText("UI Only")
                 self.multimeter_port_name.setText("")
 
             self.multimeter_status = QLabel()
@@ -793,7 +822,7 @@ class QtApplication(QWidget):
         self.NewTestButton.clicked.connect(self.openNewTest)
         self.NewTestButton.clicked.connect(self.manual_control_warning)
         self.NewTestButton.setDisabled(True)
-        if self.ActiveFC7s != {} or allow_test_without_fc7:
+        if self.ActiveFC7s != {} or self.ui_testing:
             self.NewTestButton.setDisabled(False)
         if self.ProcessingTest:
             self.NewTestButton.setDisabled(True)
@@ -1161,7 +1190,7 @@ class QtApplication(QWidget):
             return
         
     def openNewTest(self):
-        if allow_test_without_fc7 and not self.ActiveFC7s:
+        if self.ui_testing and not self.ActiveFC7s:
             FwModule = [
                 QtBeBoard(BeBoardID="0", boardName="fc7.dummy", ipAddress="0.0.0.0")
             ]

--- a/Gui/QtGUIutils/QtApplication.py
+++ b/Gui/QtGUIutils/QtApplication.py
@@ -820,7 +820,7 @@ class QtApplication(QWidget):
         self.NewTestButton.setMinimumHeight(kMinimumHeight)
         self.NewTestButton.setMaximumHeight(kMaximumHeight)
         self.NewTestButton.clicked.connect(self.openNewTest)
-        self.NewTestButton.clicked.connect(self.manual_control_warning)
+        # Manual control warning is shown after the start window is created.
         self.NewTestButton.setDisabled(True)
         if self.ActiveFC7s != {} or self.ui_testing:
             self.NewTestButton.setDisabled(False)
@@ -1202,6 +1202,9 @@ class QtApplication(QWidget):
             ]
         print(f"FwModule is: {[board.getBoardName() for board in FwModule]}")
         self.StartNewTest = QtStartWindow(self, FwModule)
+        self.StartNewTest.raise_()
+        self.StartNewTest.activateWindow()
+        self.manual_control_warning(parent=self.StartNewTest)
 
         self.NewTestButton.setDisabled(True)
         self.LogoutButton.setDisabled(True)
@@ -1362,17 +1365,20 @@ class QtApplication(QWidget):
     ###############################################################
     ##  Main page and related functions  (END)
     ###############################################################
-    def manual_control_warning(self):
+    def manual_control_warning(self, parent=None):
         if not self.instruments:
-            QMessageBox.warning(
-                self,
-                "Manual Control",
+            message_box = QMessageBox(parent or self)
+            message_box.setIcon(QMessageBox.Warning)
+            message_box.setWindowTitle("Manual Control")
+            message_box.setText(
                 "You have opted for manual power supply "
                 "control. If this is incorrect edit "
                 "icicle_instrument_setup in siteConfig.py. "
-                "Otherwise, proceed at your own risk",
-                QMessageBox.Ok,
+                "Otherwise, proceed at your own risk"
             )
+            message_box.setStandardButtons(QMessageBox.Ok)
+            message_box.setWindowModality(Qt.WindowModal)
+            message_box.exec()
 
     def closeEvent(self, event):
         reply = QMessageBox.question(

--- a/Gui/QtGUIutils/QtApplication.py
+++ b/Gui/QtGUIutils/QtApplication.py
@@ -28,6 +28,7 @@ from felis.felis_helpers import get_accountInfo
 from Gui.QtGUIutils.Loading import LoadingWheel, LoadingThread
 
 import Gui.siteSettings as site_settings
+from Gui.siteSettings import allow_test_without_fc7
 from Gui.GUIutils.FirmwareUtil import fwStatusParser, FwStatusCheck
 from Gui.QtGUIutils.QtRunWindow import QtRunWindow
 from Gui.QtGUIutils.LaudaApp import LaudaWidget
@@ -792,7 +793,7 @@ class QtApplication(QWidget):
         self.NewTestButton.clicked.connect(self.openNewTest)
         self.NewTestButton.clicked.connect(self.manual_control_warning)
         self.NewTestButton.setDisabled(True)
-        if self.ActiveFC7s != {}:
+        if self.ActiveFC7s != {} or allow_test_without_fc7:
             self.NewTestButton.setDisabled(False)
         if self.ProcessingTest:
             self.NewTestButton.setDisabled(True)
@@ -1160,11 +1161,16 @@ class QtApplication(QWidget):
             return
         
     def openNewTest(self):
-        FwModule = [
-            board_object
-            for firmware, board_object in self.FwDict.items()
-            if firmware in self.ActiveFC7s.values()
-        ]
+        if allow_test_without_fc7 and not self.ActiveFC7s:
+            FwModule = [
+                QtBeBoard(BeBoardID="0", boardName="fc7.dummy", ipAddress="0.0.0.0")
+            ]
+        else:
+            FwModule = [
+                board_object
+                for firmware, board_object in self.FwDict.items()
+                if firmware in self.ActiveFC7s.values()
+            ]
         print(f"FwModule is: {[board.getBoardName() for board in FwModule]}")
         self.StartNewTest = QtStartWindow(self, FwModule)
 

--- a/Gui/QtGUIutils/QtStartWindow.py
+++ b/Gui/QtGUIutils/QtStartWindow.py
@@ -32,12 +32,12 @@ from Gui.siteSettings import (
     ModuleCurrentMap,
     icicle_instrument_setup,
     WorkingChannels,
-    cooler
+    cooler,
+    UI_testing
 )
 from icicle.icicle.instrument_cluster import DummyInstrument
 from Gui.QtGUIutils.TestSearchCombo import configure_test_combo
 from InnerTrackerTests.TestSequences import TestList
-
 
 
 logger = get_logger(__name__)
@@ -560,6 +560,9 @@ class QtStartWindow(QWidget):
         self.master.ExitButton.setDisabled(False)
 
     def checkFwPar(self, pfirmwareName):
+        if UI_testing:
+            self.passCheck = True
+            return True
         GlobalCheck = True
         for item in self.ModuleList:
             # item.checkFwPar(pfirmwareName, item.module.getType())

--- a/Gui/python/TestHandler.py
+++ b/Gui/python/TestHandler.py
@@ -65,10 +65,29 @@ import Gui.siteSettings as site_settings
 from Gui.python.logging_config import get_logger
 from Gui.python.CustomizedWidget import chip_iref_db
 from InnerTrackerTests.TestSequences import CompositeTests_Modules, Test_to_Ph2ACF_Map, OpenBumpTest
-from Gui.siteSettings import icicle_instrument_setup
+from Gui.siteSettings import icicle_instrument_setup, UI_testing
 
 
 logger = get_logger(__name__)
+
+
+class DummyInstrumentCluster:
+    def __init__(self):
+        self._module_dict = {}
+        self._instrument_dict = {}
+        self.powering_groups = {}
+
+    def get_modules(self):
+        return {}
+
+    def status(self):
+        return {}
+
+    def __getattr__(self, name):
+        def _noop(*args, **kwargs):
+            return None
+
+        return _noop
 
 
 # Setup enum for ProgressigMode. This ensures we don't use any unhandled states on accident
@@ -100,6 +119,8 @@ class TestHandler(QObject):
         super(TestHandler, self).__init__()
         self.master = master
         self.instruments = self.master.instruments
+        if self.instruments is None:
+            self.instruments = DummyInstrumentCluster()
         self.mod_dict = {}
         self.fused_dict_index = [
             -1,
@@ -510,6 +531,9 @@ class TestHandler(QObject):
         self.initializeRD53Dict()
 
     def runTest(self, reRun=False):
+        if UI_testing:
+            self._simulate_run()
+            return
         if reRun:
             self.halt = False
             self.testIndexTracker = 0
@@ -525,6 +549,45 @@ class TestHandler(QObject):
         else:
             QMessageBox.information(None, "Warning", "Not a valid test", QMessageBox.Ok)
             return
+
+    def _simulate_run(self):
+        tests = self.test_list if isCompositeTest(self.info) else (self.info,)
+        for index, test_name in enumerate(tests):
+            self.currentTest = test_name
+            self.testIndexTracker = index
+            for console in getattr(self.runwindow, "ConsoleViews", []):
+                self.outputString.emit(
+                    f"[SIM] Running {test_name} (no hardware)",
+                    console,
+                )
+
+            for progress in (0, 25, 50, 75, 100):
+                for fw_index in range(len(self.firmware)):
+                    bar = self.runwindow.ResultWidget.ProgressBars[fw_index][index]
+                    self.updateProgressBar.emit(
+                        bar, progress, f"{progress}% (sim)"
+                    )
+                time.sleep(0.05)
+
+            for fw_index in range(len(self.firmware)):
+                runtime = self.runwindow.ResultWidget.runtimes[fw_index][index]
+                runtime.setText("0.0s (sim)")
+
+            results = [
+                {
+                    module.getModuleName(): (
+                        True,
+                        "Simulated run (no hardware)",
+                    )
+                }
+                for module in self.modules
+            ]
+            self.finished_tests.append(test_name)
+            self.updateValidation.emit(results)
+            self.updateFinishedTests.emit(self.finished_tests)
+            self.historyRefresh.emit()
+
+        self.stepFinished.emit(True)
 
     # This loops over all the tests by using the on_finish pyqt decorator defined below
     def runCompositeTest(self, testName):

--- a/Gui/siteConfig.py
+++ b/Gui/siteConfig.py
@@ -60,7 +60,10 @@ coldboxRoomTemp = 10
 
 # Set this variable to use your powersupplies manually
 # IF THIS VARIABLE IS SET, THEN ICICLE_INSTRUMENT_SETUP WILL NOT BE USED
-manual_powersupply_control = False
+manual_powersupply_control = True
+
+# Allow UI-only testing without FC7 connections.
+allow_test_without_fc7 = True
 
 # Load instrument setup from json file
 # If the json filename contains 'auto', channels will be automatically assigned as listed in Working Channels

--- a/Gui/siteConfig.py
+++ b/Gui/siteConfig.py
@@ -62,8 +62,10 @@ coldboxRoomTemp = 10
 # IF THIS VARIABLE IS SET, THEN ICICLE_INSTRUMENT_SETUP WILL NOT BE USED
 manual_powersupply_control = True
 
-# Allow UI-only testing without FC7 connections.
-allow_test_without_fc7 = True
+# Enable UI-only testing mode (no FC7 or hardware connections).
+UI_testing = True
+if UI_testing:
+	manual_powersupply_control = True
 
 # Load instrument setup from json file
 # If the json filename contains 'auto', channels will be automatically assigned as listed in Working Channels
@@ -131,6 +133,8 @@ forward_bias_voltage = 0.5 #positive voltage used to run a forward-reverse bias 
     
 FC7List = icicle_instrument_setup['fc7_address_dict']
 icicle_instrument_setup.pop('fc7_address_dict')
+if UI_testing:
+	FC7List = {}
 
 ## Update this list with all working TEC channels in your coldbox
 ## Channel assignments will follow this list sequentially per number of modules entered in the GUI

--- a/Gui/siteConfig.py
+++ b/Gui/siteConfig.py
@@ -60,10 +60,10 @@ coldboxRoomTemp = 10
 
 # Set this variable to use your powersupplies manually
 # IF THIS VARIABLE IS SET, THEN ICICLE_INSTRUMENT_SETUP WILL NOT BE USED
-manual_powersupply_control = True
+manual_powersupply_control = False
 
 # Enable UI-only testing mode (no FC7 or hardware connections).
-UI_testing = True
+UI_testing = False
 if UI_testing:
 	manual_powersupply_control = True
 


### PR DESCRIPTION
## Description
The warning message for manual controls would send the new test window behind the main qt window. This is now fixed

## Checklist
Before submitting this PR, please ensure the following:

- [X] I am using the **correct branches/versions** of all submodules.
- [X] I have successfully **launched the Simplified GUI**.
- [X] I have successfully **run a test in the Simplified GUI**.
- [X]  I have successfully **run a test in the Expert GUI**.
