### PR TITLE
Fixingopenbumpbugformulifc7

### DIFF
--- a/Gui/GUIutils/guiUtils.py
+++ b/Gui/GUIutils/guiUtils.py
@@ -471,10 +471,10 @@ def GenerateXMLConfig(BeBoard, testName, outputDir, txt_files:dict, **arg):
                     RxPolarities,
                     txt_file,
                 )
-
+                logger.info("Generating the xml file now")
                 chip_settings = FESettings_Dict[testName][registerKey].copy()
-                chip_settings['VREF_ADC'] = chip.getVREF()
-                chip_settings['INJ_CAP'] = chip.getCINJ()
+                chip_settings['VREF_ADC'] = str(1e3*float(chip.getVREF()))
+                chip_settings['INJ_CAP'] = str(1e13*float(chip.getCINJ()))
                 chip_settings['DAC_PREAMP_L_LIN'] = chip.getDAC_PREAMP_L_LIN()
                 chip_settings['DAC_PREAMP_R_LIN'] = chip.getDAC_PREAMP_R_LIN()
                 chip_settings['DAC_PREAMP_TL_LIN'] = chip.getDAC_PREAMP_TL_LIN()

--- a/Gui/python/CustomizedWidget.py
+++ b/Gui/python/CustomizedWidget.py
@@ -888,7 +888,7 @@ class ChipBox(QWidget):
                 chipdatadicts = [entry for entry in data["bare_module_data"] if entry["KIND_OF_PART"] == "CROC Chip"]
 
                 chipdata = {}
-
+                logger.info("Converting the units of chip data")
                 for i, chip in enumerate(chipdatadicts):
                     chipdata[chipidmap[str(i)]] = {
                     "VDDA": str(chip.get("VDDA_TRIM_CODE", "0")),
@@ -896,7 +896,7 @@ class ChipBox(QWidget):
                     "IREF": str(chip.get("IREF_TRIM_CODE", "0")),
                     "EFUSE": str(chip.get("EFUSE_CODE", "0")),
                     "VREF": str(chip.get("VREF_ADC_V", "0")),
-                    "CINJ": str(chip.get("INJ_CAPACIT_F", "0")),
+                    "CINJ": str(chip.get("INJ_CAPACIT_F", "8e-12")),
                     "ADC_OFFSET_VOLT": str(1e4*float(chip.get("ADC_OFF_V", "0"))),
                     "ADC_MAXIMUM_VOLT": str(1e3*(4096*float(chip.get("ADC_SLO", "0"))+float(chip.get("ADC_OFF_V", "0")))),
                     "DAC_PREAMP_L_LIN": str(chip.get("probe_data", {}).get("DAC_PREAMP_L_LIN", "0")),
@@ -942,8 +942,10 @@ class ChipBox(QWidget):
                 ]
                 chipdata = {}
                 for i, chip in enumerate(chipdatadicts):
+                    if "CINJ" in chip:
+                        chip["CINJ"] = str(float(chip["CINJ"]) * 1e-12)
+                    logger.debug(f"The chipdata is chipdata: {chip}")
                     chipdata[chipidmap[str(i)]] = chip
-                
                 logger.info(f"Fetched chip data for {moduleName} from Purdue database: {chipdata}")
                 if module_name_key:
                     chip_data_cache[module_name_key] = chipdata
@@ -1438,20 +1440,21 @@ class BeBoardBox(QWidget):
                     self.ChipWidgetDict[module].getADC_OFFSET_VOLT(chipID)
                 )
                 
-                try:
-                    vref_value = float(self.ChipWidgetDict[module].getVREF(chipID))
-                except Exception:
-                    vref_value = 0.8
+                #try:
+                #    vref_value = float(self.ChipWidgetDict[module].getVREF(chipID))
+                #except Exception:
+                #    vref_value = 0.8
                     
                 Module.getChips()[chipID].setVREF(
-                    (1000 * vref_value)
+                    self.ChipWidgetDict[module].getVREF(chipID)
                 )
-                try:
-                    cinj_value = float(self.ChipWidgetDict[module].getCINJ(chipID))
-                except Exception:
-                    cinj_value = 8
+
+                #try:
+                #    cinj_value = float(self.ChipWidgetDict[module].getCINJ(chipID))
+                #except Exception:
+                #    cinj_value = 8
                 Module.getChips()[chipID].setCINJ(
-                    (1e13 * cinj_value)
+                    self.ChipWidgetDict[module].getCINJ(chipID)
                 )
 
             # Add the QtModule object to the currently selected Optical Group

--- a/Gui/python/TestHandler.py
+++ b/Gui/python/TestHandler.py
@@ -2065,6 +2065,15 @@ created by Ph2_ACF is empty."
         self.saveConfigs(process_index=processIndex)
         # Don't continue on sequence until all processes have finished the current test
         if self._openBumpTest_running:
+            self.finished_processes += 1
+            expected_processes = (
+                self.active_process_count
+                if self.active_process_count > 0
+                else len(self.run_processes)
+            )
+            if not self.finished_processes == expected_processes:
+                return
+            self.finished_processes = 0
             self._openBumpTest_subtest_index += 1
             if self._openBumpTest_subtest_index < len(OpenBumpTest):
                 subtest = OpenBumpTest[self._openBumpTest_subtest_index]
@@ -2082,16 +2091,17 @@ created by Ph2_ACF is empty."
                 self._openBumpTest_running = False
 
         # Ensure that all processes have finished before continuing
-        self.finished_processes += 1
-        expected_processes = (
-            self.active_process_count
-            if self.active_process_count > 0
-            else len(self.run_processes)
-        )
-        if not self.finished_processes == expected_processes:
-            return
+        else:
+            self.finished_processes += 1
+            expected_processes = (
+                self.active_process_count
+                if self.active_process_count > 0
+                else len(self.run_processes)
+            )
+            if not self.finished_processes == expected_processes:
+                return
 
-        self.finished_processes = 0
+            self.finished_processes = 0
 
         # validate the results
         logger.debug("About to run validateTest()")

--- a/run_Docker.sh
+++ b/run_Docker.sh
@@ -7,7 +7,7 @@ bash check_configuration_files.sh run_Docker.sh Gui/siteConfig.py
 SOCK=/tmp/.X11-unix; XAUTH=/tmp/.docker.xauth; xauth nlist $DISPLAY | sed -e 's/^..../ffff/' | xauth -f $XAUTH nmerge -; chmod 777 $XAUTH;
 
 ######### Specify the docker image to use #################
-IMAGE_NAME="osupixels/ph2_acf_gui_dev:v5.0.0-pre"
+IMAGE_NAME="osupixels/ph2_acf_gui_dev:v5.1.0-pre-v3"
 #IMAGE_NAME="majoyce2/ph2_acf_gui_purdue:latest"
 #IMAGE_NAME="majoyce2/ph2_acf_gui_user:latest"
 #IMAGE_NAME="local/testimagemay29user"


### PR DESCRIPTION
## Description
This fixes a racing condition caused by parallel openbump tests running.  This fix was already implimented for the rest of the tests but applying it to openbump tests was missed the first time.  We also fixed conversion issues between parameters pulled from the central DB and the Purdue DB.

## Checklist
Before submitting this PR, please ensure the following:

- [x] I am using the **correct branches/versions** of all submodules.
- [x] I have successfully **launched the Simplified GUI**.
- [ ] I have successfully **run a test in the Simplified GUI**.
- [x] I have successfully **run a test in the Expert GUI**.


## Changes Made
Added checks for openbump process status and applied appropriate conversion to parameters pulled from databases.

## Testing
Ran second part of the common assembly test with 7 modules in parallel and successfully uploaded results to Panthera.  Tested first part of the common assembly test for single modules (1x2 TFPX modules) and successfully uploaded the results to Panthera.

