### PR TITLE
Update dc ainterface

### DIFF
--- a/Gui/python/CentralDBInterface.py
+++ b/Gui/python/CentralDBInterface.py
@@ -2,12 +2,31 @@ import os
 
 
 def ExtractChipData(chipserial):
-    # sqlcommand = f"select c.PART_NAME_LABEL, c.VDDA_TRIM_CODE, c.VDDD_TRIM_CODE, c.EFUSE_CODE from trker_cmsr.c18220 c where c.PART_NAME_LABEL = '{chipserial}'" #example of chipserial is N61F26_16E6_45
-    command = f'''python rhapi.py -nx -u https://cmsdca.cern.ch/trk_rhapi1 "select c.PART_NAME_LABEL, c.VDDA_TRIM_CODE, c.VDDD_TRIM_CODE, c.EFUSE_CODE from trker_cmsr.c13420 c where c.PART_NAME_LABEL like '%{chipserial}%'"'''
-    # chipdata = os.popen(command).read()
-    chipdataoutput = os.popen(command).read()
+    DB_interface_step1 = f'''python python/rhapi.py --login --no-save-password --clean -u https://cmsdca.cern.ch/trk_rhapi1 "select c.* from trker_cmsr.c18220 c where c.PART_NAME_LABEL = '{chipserial}'"'''
+    DB_interface_step2 = f'''python python/rhapi.py --login --no-save-password --clean -u https://cmsdca.cern.ch/trk_rhapi1 "select c.CROC_DATA_ID, c.Y from trker_cmsr.c18240 c where c.PART_NAME_LABEL = '{chipserial}' and c.CROC_DATA_ID like 'DAC_%_LIN' and c.X = 0"'''
+    chipdataoutput_step1 = os.popen(DB_interface_step1).read()
+    chipdataoutput_step1 = chipdataoutput_step1.split("\n")
+    datelabel_step1 = chipdataoutput_step1[0].split(",")
+    datavalue_step1 = chipdataoutput_step1[1].split(",")
+    chipdata_step1 = dict(zip(datelabel_step1, datavalue_step1))
+    chipdataoutput = os.popen(DB_interface_step2).read()
     chipdataoutput = chipdataoutput.split("\n")
-    datalabel = chipdataoutput[0].split(",")
-    datavalue = chipdataoutput[1].split(",")
-    chipdata = dict(zip(datalabel, datavalue))
+    chipdata = {}
+    for entry in chipdataoutput:
+        if "," in entry:
+            datalabel = entry.split(",")[0]
+            datavalue = entry.split(",")[1]
+            chipdata[datalabel] = datavalue
+    chipdata.update(chipdata_step1)
+
+    ##Convert to correct units and map dictionary keys to xml expectations
+    chipdata.update({"VDDA": str(chipdata.get("VDDA_TRIM_CODE", "8")),
+    "VDDD": str(chipdata.get("VDDD_TRIM_CODE", "8")),
+    "IREF": str(chipdata.get("IREF_TRIM_CODE", "0")),
+    "EFUSE": str(chipdata.get("EFUSE_CODE", "0")),
+    "VREF": str(chipdata.get("VREF_ADC_V", "0")),
+    "CINJ": str(chipdata.get("INJ_CAPACIT_F", "8e-12")),
+    "ADC_OFFSET_VOLT": str(1e4*float(chipdata.get("ADC_OFF_V", "0"))),
+    "ADC_MAXIMUM_VOLT": str(1e3*(4096*float(chipdata.get("ADC_SLO", "0"))+float(chipdata.get("ADC_OFF_V", "0")))),
+    })
     return chipdata

--- a/Gui/python/CentralDBInterface.py
+++ b/Gui/python/CentralDBInterface.py
@@ -1,6 +1,8 @@
 import os
 
-
+def DCA_login():
+    DB_login_command = f'python python/rhapi.py --login --no-save-password --clean -u https://cmsdca.cern.ch/trk_rhapi1'
+    DB_login_output = os.popen(DB_login_command).read()
 def ExtractChipData(chipserial):
     DB_interface_step1 = f'''python python/rhapi.py --login --no-save-password --clean -u https://cmsdca.cern.ch/trk_rhapi1 "select c.* from trker_cmsr.c18220 c where c.PART_NAME_LABEL = '{chipserial}'"'''
     DB_interface_step2 = f'''python python/rhapi.py --login --no-save-password --clean -u https://cmsdca.cern.ch/trk_rhapi1 "select c.CROC_DATA_ID, c.Y from trker_cmsr.c18240 c where c.PART_NAME_LABEL = '{chipserial}' and c.CROC_DATA_ID like 'DAC_%_LIN' and c.X = 0"'''

--- a/Gui/python/CentralDBInterface.py
+++ b/Gui/python/CentralDBInterface.py
@@ -3,6 +3,7 @@ import os
 def DCA_login():
     DB_login_command = f'python python/rhapi.py --login --no-save-password --clean -u https://cmsdca.cern.ch/trk_rhapi1'
     DB_login_output = os.popen(DB_login_command).read()
+    return DB_login_output.strip("\n")
 def ExtractChipData(chipserial):
     DB_interface_step1 = f'''python python/rhapi.py --login --no-save-password --clean -u https://cmsdca.cern.ch/trk_rhapi1 "select c.* from trker_cmsr.c18220 c where c.PART_NAME_LABEL = '{chipserial}'"'''
     DB_interface_step2 = f'''python python/rhapi.py --login --no-save-password --clean -u https://cmsdca.cern.ch/trk_rhapi1 "select c.CROC_DATA_ID, c.Y from trker_cmsr.c18240 c where c.PART_NAME_LABEL = '{chipserial}' and c.CROC_DATA_ID like 'DAC_%_LIN' and c.X = 0"'''

--- a/Gui/python/CustomizedWidget.py
+++ b/Gui/python/CustomizedWidget.py
@@ -911,7 +911,7 @@ class ChipBox(QWidget):
                     "DAC_COMP_TA_LIN": str(chip.get("probe_data", {}).get("DAC_COMP_TA_LIN", "0")),
                     "DAC_LDAC_LIN": str(chip.get("probe_data", {}).get("DAC_LDAC_LIN", "0")),
                     }
-                logger.info(f"Fetched chip data for {name_label} from CMS database: {chipdata}")
+                logger.debug(f"Fetched chip data for {name_label} from CMS database: {chipdata}")
                 if module_name_key:
                     chip_data_cache[module_name_key] = chipdata
                 return chipdata
@@ -944,9 +944,9 @@ class ChipBox(QWidget):
                 chipdata = {}
                 for i, chip in enumerate(chipdatadicts):
                     chipdata[chipidmap[str(i)]] = ExtractChipData(chip["S/N"])
-                    logger.info(f"Extracted chip data for {chip['S/N']} from Purdue database: {chipdata[chipidmap[str(i)]]}")
+                    logger.debug(f"Extracted chip data for {chip['S/N']} from Purdue database: {chipdata[chipidmap[str(i)]]}")
                     
-                logger.info(f"Fetched chip data for {moduleName} from Purdue database: {chipdata}")
+                logger.debug(f"Fetched chip data for {moduleName} from Purdue database: {chipdata}")
                 if module_name_key:
                     chip_data_cache[module_name_key] = chipdata
                 return chipdata

--- a/Gui/python/CustomizedWidget.py
+++ b/Gui/python/CustomizedWidget.py
@@ -41,6 +41,7 @@ from InnerTrackerTests.FESettings import (
 )
 # from Gui.GUIutils.FirmwareUtil import *
 # from Gui.QtGUIutils.QtFwCheckDetails import *
+from Gui.python.CentralDBInterface import ExtractChipData
 
 from Gui.python.logging_config import get_logger
 
@@ -942,10 +943,9 @@ class ChipBox(QWidget):
                 ]
                 chipdata = {}
                 for i, chip in enumerate(chipdatadicts):
-                    if "CINJ" in chip:
-                        chip["CINJ"] = str(float(chip["CINJ"]) * 1e-12)
-                    logger.debug(f"The chipdata is chipdata: {chip}")
-                    chipdata[chipidmap[str(i)]] = chip
+                    chipdata[chipidmap[str(i)]] = ExtractChipData(chip["S/N"])
+                    logger.info(f"Extracted chip data for {chip['S/N']} from Purdue database: {chipdata[chipidmap[str(i)]]}")
+                    
                 logger.info(f"Fetched chip data for {moduleName} from Purdue database: {chipdata}")
                 if module_name_key:
                     chip_data_cache[module_name_key] = chipdata

--- a/prepare_Ph2ACF.sh
+++ b/prepare_Ph2ACF.sh
@@ -34,6 +34,9 @@ fi
 
 cd ${GUI_dir}/Gui
 
+echo "Logging into DCA to cache credentials for database access..."
+python3 python/rhapi.py --login --no-save-password --clean -u https://cmsdca.cern.ch/trk_rhapi1
+
 echo "You can now open the GUI by doing 'python3 QtApplication.py'."
 
 python3 QtApplication.py


### PR DESCRIPTION
## Description
Adds interface with the DCA for extracting chip parameters to use during testing.  Default is to check registry for modules, but reverts to using rhapi with DCA on a chip-by-chip basis if modules are not found in the registry.

## Checklist
Before submitting this PR, please ensure the following:

- [x] I am using the **correct branches/versions** of all submodules.
- [ ] I have successfully **launched the Simplified GUI**.
- [ ] I have successfully **run a test in the Simplified GUI**.
- [x] I have successfully **run a test in the Expert GUI**.


## Changes Made
Replaced direct pull of data from Purdue DB with a simple pull of the chip serial numbers which are then used by rhapi to query the DCA for chip parameters.  The login to the DCA is done when the GUI is first started.  The user will need to provide their CERN username, password, and otp (I used Aegis for this).  The GUI login is the same as before, which is the login credentials for Panthera.

## Testing
Ran Pixelalive on registered module and non-registered module and verified that parameters matched what they should be in the generated xml file.

## Additional Notes

