### PR TITLE
Making firmware image load to multiple fc7s for multimodule testing

### DIFF
--- a/Gui/QtGUIutils/QtStartWindow.py
+++ b/Gui/QtGUIutils/QtStartWindow.py
@@ -104,7 +104,7 @@ class SummaryBox(QWidget):
             # updating uri value in template xml file with correct fc7 ip address, as specified in siteSettings.py
             # fc7_ip = site_settings.FC7List[pfirmwareName] #Commented because I don't think we need it.  Remove line after test.
             print("The fc7 ip is: {0}".format(fc7_ip))
-            uricmd = "sed -i -e 's/fc7-1/{0}/g' {1}/Gui/CMSIT_{2}.xml".format(
+            uricmd = "sed -i -e 's/target=[^:]*/target={0}/' {1}/Gui/CMSIT_{2}.xml".format(
                 fc7_ip, os.environ.get("GUI_dir"), boardtype
             )
             subprocess.call([uricmd], shell=True)


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of the changes in this PR. -->
When using multiple FC7s, the GUI was only loading the firmare image onto the first FC7 because `sed` was looking for a specific string pattern to replace which didn't exist anymore.  This PR makes the `sed` command that was used more flexible so that it will work inside a loop, which is what is needed to load firmware on multiple FC7s.

## Checklist
Before submitting this PR, please ensure the following:

- [x] I am using the **correct branches/versions** of all submodules.
- [x] I have successfully **launched the Simplified GUI**.
- [x] I have successfully **run a test in the Simplified GUI**.
- [x] I have successfully **run a test in the Expert GUI**.

## Related Issues
<!-- List any related issues, e.g. "Fixes #123" or "Closes #456". -->

## Changes Made
<!-- Summarize the major changes in this PR. -->

## Testing
<!-- Describe how you tested your changes, including commands run, configurations used, etc. -->

## Additional Notes
<!-- Add any additional comments or context if needed. -->
