### PR TITLE
OBT makes 3 XMLs for each subtest, but still runs as 1 test

### DIFF
--- a/Gui/GUIutils/guiUtils.py
+++ b/Gui/GUIutils/guiUtils.py
@@ -274,21 +274,29 @@ def SetupXMLConfigfromFile(InputFile, Output_Dir, BeBoardName=""):
         logger.error(traceback.format_exc())
 
     try:
-        shutil.copyfile(InputFile, 
-                        os.path.join(Output_Dir, f"CMSIT_{BeBoardName}.xml"))
+        # Extract the base filename from InputFile to preserve test name in output
+        # InputFile is typically like: /path/to/.tmp/CMSIT_fc7_PixelAlive_highcharge_xtalk.xml
+        # We want to preserve the test name, so output should be: CMSIT_fc7_PixelAlive_highcharge_xtalk.xml
+        input_basename = os.path.basename(InputFile)
+        output_filename = input_basename if not input_basename.endswith(".changed") else input_basename[:-8]  # Remove .changed extension
+        output_path = os.path.join(Output_Dir, output_filename)
+        
+        shutil.copyfile(InputFile, output_path)
+        logger.debug(f"Copied XML file from {InputFile} to {output_path}")
 
     except OSError:
         print("Can not copy the XML files {0} to {1}".format(InputFile, Output_Dir))
         print(traceback.format_exc())
     try:
-            shutil.copyfile("{0}/CMSIT_{1}.xml".format(Output_Dir, BeBoardName),
-            "{0}/test/CMSIT_{1}.xml".format(os.environ.get("PH2ACF_BASE_DIR"), BeBoardName)
+            # Also copy to Ph2ACF test directory, preserving the filename
+            shutil.copyfile(output_path,
+            "{0}/test/{1}".format(os.environ.get("PH2ACF_BASE_DIR"), output_filename)
             )
                    
     except OSError:
         logger.error(
-            "Can not copy {0}/CMSIT_{1}.xml to {2}/test/CMSIT_{1}.xml".format(
-                Output_Dir, BeBoardName, os.environ.get("PH2ACF_BASE_DIR")
+            "Can not copy {0} to {1}/test/{2}".format(
+                output_path, os.environ.get("PH2ACF_BASE_DIR"), output_filename
             )
         )
         print(traceback.format_exc())

--- a/Gui/python/TestHandler.py
+++ b/Gui/python/TestHandler.py
@@ -582,6 +582,8 @@ class TestHandler(QObject):
 
         if isCompositeTest(testName):
             self.runCompositeTest(testName)
+        elif testName == "OpenBumpTest":
+            self.runOpenBumpTest()
         elif isSingleTest(testName):
             self.runSingleTest(testName)
         else:

--- a/Gui/python/TestValidator.py
+++ b/Gui/python/TestValidator.py
@@ -3,7 +3,7 @@ import ROOT
 import traceback
 import re
 
-from InnerTrackerTests.TestSequences import Test_to_Ph2ACF_Map, CompositeTests_Modules
+from InnerTrackerTests.TestSequences import Test_to_Ph2ACF_Map, CompositeTests_Modules, OpenBumpTest
 from Gui.GUIutils.guiUtils import isCompositeTest
 from Gui.python.logging_config import get_logger
 
@@ -171,6 +171,43 @@ def ResultGrader(
                 name_test = f"{testIndexInSequence:02d}_{testName}",
                 type_test = "commtest",
                 comm_result=comm_result,
+            )
+
+        elif testName == "OpenBumpTest":
+            # Collect all 3 XML files from the OpenBumpTest subtests
+            relevant_files = []
+            
+            # Collect all XML files (one for each subtest: highcharge_xtalk, coupled_xtalk, uncoupled_xtalk)
+            for file in os.listdir(outputDir):
+                if file.endswith(".xml"):
+                    relevant_files.append(os.path.join(outputDir, file))
+            
+            # Also collect PixelAlive root files from the subtests
+            for file in os.listdir(outputDir):
+                if "PixelAlive" in file and file.endswith(".root"):
+                    relevant_files.append(os.path.join(outputDir, file))
+            
+            # Collect any .json files
+            for file in os.listdir(outputDir):
+                if file.endswith(".json"):
+                    relevant_files.append(os.path.join(outputDir, file))
+            
+            logger.info(f"OpenBumpTest collected files: {relevant_files}")
+            
+            _1, _2 = felis.set_module(
+                name_module = module_name,
+                subdetector = module_type.split(" ")[0],
+                type_module = module_type.split(" ")[2].replace("Quad", "2x2"),
+                croc_version = module_version.strip("v"),
+                has_sensor = True,
+                type_sensor = sensor_type,
+                link_production_db = f"https://www.physics.purdue.edu/cmsfpix/Phase2_Test/w.php?sn={module_name}",
+            )
+            status, message, sanity, explanation = felis.set_result(
+                paths_files = relevant_files,
+                name_module = module_name,
+                name_test = f"{testIndexInSequence:02d}_{testName}",
+                type_test = "crosstalk",
             )
 
         else:


### PR DESCRIPTION
## Description
OpenBumpTest now creates 3 separate XML files for each subtest rather than one that keeps getting overwritten. Also fixes a key error from running openBumpTest. 

## Checklist
Before submitting this PR, please ensure the following:

- [x] I am using the **correct branches/versions** of all submodules.
- [x] I have successfully **launched the Simplified GUI**.
- [x] I have successfully **run a test in the Simplified GUI**.
- [x] I have successfully **run a test in the Expert GUI**.

## Related Issues
#686 

## Changes Made
big block in testValidator.py that collects the 3 XML files from the OBT subtests. 

In testHandler, adds 2 lines to run the runOpenBumpTest function when OpenBumpTest is the current test. (Im 99% certain that was already there when I originally made openBumpTest, and i have no idea how it got removed, I think thats why I was getting the Key Error thing.) 

in guiUtils.py: Copies the input XML file into the output directory using standardized CMSIT_<BeBoardName>.xml name and its original test-specific filename. .

## Testing
ran openbumptest on RH0110, looked for XML files, saw all 3 existed. launched simple gui to check it still worked. ran pixelalive and openbumptest to make sure they both worked.

## Additional Notes
nah
