### PR TITLE
correct mapping for OBT subtests

### DIFF
--- a/Gui/python/TestHandler.py
+++ b/Gui/python/TestHandler.py
@@ -1151,6 +1151,19 @@ class TestHandler(QObject):
                 )
                 if process.state() != QProcess.NotRunning:
                     self.active_process_count += 1
+
+        elif self.currentTest == "OpenBumpTest" or self.currentTest in OpenBumpTest:
+            i = 0
+            for process, firmware in zip(self.run_processes, self.firmware):
+                process.start(
+                    "CMSITminiDAQ",
+                    [
+                        "-f",
+                        f"CMSIT_{firmware.getBoardName()}.xml",
+                        "-c",
+                        "{}".format(Test_to_Ph2ACF_Map[OpenBumpTest[self._openBumpTest_subtest_index]]),
+                    ],
+                )
         else:
             i = 0
             for process, firmware in zip(self.run_processes, self.firmware):


### PR DESCRIPTION
## Description
for OBT changes this: 
`"{}".format(Test_to_Ph2ACF_Map[self.currentTest]),`

to this: 
`"{}".format(Test_to_Ph2ACF_Map[OpenBumpTest[self._openBumpTest_subtest_index]]),`

## Checklist
Before submitting this PR, please ensure the following:

- [x] I am using the **correct branches/versions** of all submodules.
- [x] I have successfully **launched the Simplified GUI**.
- [x] I have successfully **run a test in the Simplified GUI**.
- [x] I have successfully **run a test in the Expert GUI**.

## Related Issues
final step of closing #686 

## Changes Made
what I said above, made elif block for OpenBumpTest and its subtests in TestHandler with that line change. 

## Testing
reception test with RH0110

## Additional Notes
I was not able to upload to Panthera to completely verify everything but the xmls and root files and such were correct in the data/scratch folder locally. 
