### PR TITLE
Fixed the issue, where the gui would connect to the thermal chamber o…

### DIFF
--- a/Gui/QtGUIutils/QtApplication.py
+++ b/Gui/QtGUIutils/QtApplication.py
@@ -495,16 +495,6 @@ class QtApplication(QWidget):
         self.FirmwareStatus = QGroupBox("Hello, {}!".format(self.operator_name_first))
         self.FirmwareStatus.setDisabled(True)
 
-        '''
-        try: 
-            logger.debug("Attempting to connect to thermal chamber")
-            self.chamber = F4TTemperatureChamber()
-        except Exception as e:
-            logger.error("Failed to connect to thermal chamber: %s" % e)
-            self.chamber = None
-        '''
-
-
         self.StatusList = [
             self.create_status_label("Panthera DB", self.panthera_connected),
         ]
@@ -1028,7 +1018,6 @@ class QtApplication(QWidget):
 
             try:
                 try:
-                    #self.instruments = InstrumentCluster(**self.device_settings)
                     self.instruments = self.connect_instruments_with_retry()
                 except ValueError:
                     pass
@@ -1038,14 +1027,12 @@ class QtApplication(QWidget):
                 lv_on = False
                 hv_on = False
 
-
                 try: 
                     logger.debug("Attempting to connect to thermal chamber")
                     self.chamber = F4TTemperatureChamber()
                 except Exception as e:
                     logger.error("Failed to connect to thermal chamber: %s" % e)
                     self.chamber = None
-
 
                 for number in self.instruments.get_modules().keys():
                     if self.instruments.status()[number]["hv"]:

--- a/Gui/QtGUIutils/QtApplication.py
+++ b/Gui/QtGUIutils/QtApplication.py
@@ -495,13 +495,14 @@ class QtApplication(QWidget):
         self.FirmwareStatus = QGroupBox("Hello, {}!".format(self.operator_name_first))
         self.FirmwareStatus.setDisabled(True)
 
-        
+        '''
         try: 
             logger.debug("Attempting to connect to thermal chamber")
             self.chamber = F4TTemperatureChamber()
         except Exception as e:
             logger.error("Failed to connect to thermal chamber: %s" % e)
             self.chamber = None
+        '''
 
 
         self.StatusList = [
@@ -1037,15 +1038,14 @@ class QtApplication(QWidget):
                 lv_on = False
                 hv_on = False
 
-                '''
-                ### Need to add a conditional so that it will check if the thermal chamber exists before connecting to it.
+
                 try: 
                     logger.debug("Attempting to connect to thermal chamber")
                     self.chamber = F4TTemperatureChamber()
                 except Exception as e:
                     logger.error("Failed to connect to thermal chamber: %s" % e)
                     self.chamber = None
-                '''
+
 
                 for number in self.instruments.get_modules().keys():
                     if self.instruments.status()[number]["hv"]:


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of the changes in this PR. -->
The GUI upon starting would connect to all devices soon upon login; this is not desirable. The fix herein addresses such that, the connection to all devices is established when you press the "connect to all devices" button in the gui.

## Checklist
Before submitting this PR, please ensure the following:

- [ ] I am using the **correct branches/versions** of all submodules.
- [ ] I have successfully **launched the Simplified GUI**.
- [ ] I have successfully **run a test in the Simplified GUI**.
- [ ] I have successfully **run a test in the Expert GUI**.

## Related Issues
<!-- List any related issues, e.g. "Fixes #123" or "Closes #456". -->

## Changes Made
<!-- Summarize the major changes in this PR. -->

## Testing
<!-- Describe how you tested your changes, including commands run, configurations used, etc. -->

## Additional Notes
<!-- Add any additional comments or context if needed. -->
